### PR TITLE
Cache burst based on config upload time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ typings/
 # dotenv environment variables file
 .env
 /yarn.lock
+
+# IDE files
+.idea

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -36,8 +36,9 @@ export function checkForServiceWorkerUpdates(app, page = {}) {
 
   /* Check if the config is updated and update the service worker if true */
   else if(global && global.qtVersion) {
+    const {qtVersion: {configVersion = 0} = {}} = global;
     const {config:{'theme-attributes': pageThemeAttributes = {}} = {}} = page;
-    if((pageThemeAttributes['cache-burst'] || 0) > parseInt(global.qtversion.configVersion)) {
+    if((pageThemeAttributes['cache-burst'] || 0) > parseInt(configVersion)) {
       console.log(`updating service worker due to config change`);
       app.updateServiceWorker && app.updateServiceWorker();
     }

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -33,5 +33,24 @@ export function checkForServiceWorkerUpdates(app, page) {
     app.updateServiceWorker && app.updateServiceWorker();
   }
 
+  /* Check if the config is updated and update the service worker if true */
+
+  caches && caches.match('/route-data.json', {'ignoreSearch': true})
+    .then((response) => {
+      if (response) {
+        return response.json()
+      }
+    })
+    .then((cachedData = {}) => {
+      const {config: {'theme-attributes': cacheThemeAttributes = {}} = {}} = cachedData;
+      const {config: {'theme-attributes': pageThemeAttributes = {}} = {}} = page;
+      const cacheConfigTime = new Date(cacheThemeAttributes['cache-burst']) || 0;
+      const pageConfigTime = new Date(pageThemeAttributes['cache-burst']) || 0;
+      if((pageConfigTime - cacheConfigTime) > 0) {
+        app.updateServiceWorker && app.updateServiceWorker();
+      }
+
+    });
+
   return page;
 }

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -35,10 +35,9 @@ export function checkForServiceWorkerUpdates(app, page = {}) {
   }
 
   /* Check if the config is updated and update the service worker if true */
-  else if(window && window.qtVersion) {
-    const {qtVersion: {configVersion = 0} = {}} = window;
+  else if(global && global.qtVersion) {
     const {config:{'theme-attributes': pageThemeAttributes = {}} = {}} = page;
-    if((pageThemeAttributes['cache-burst'] || 0) > parseInt(configVersion)) {
+    if((pageThemeAttributes['cache-burst'] || 0) > parseInt(global.qtversion.configVersion)) {
       console.log(`updating service worker due to config change`);
       app.updateServiceWorker && app.updateServiceWorker();
     }

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -44,8 +44,8 @@ export function checkForServiceWorkerUpdates(app, page) {
     .then((cachedData = {}) => {
       const {config: {'theme-attributes': cacheThemeAttributes = {}} = {}} = cachedData;
       const {config: {'theme-attributes': pageThemeAttributes = {}} = {}} = page;
-      const cacheConfigTime = new Date(cacheThemeAttributes['cache-burst']) || 0;
-      const pageConfigTime = new Date(pageThemeAttributes['cache-burst']) || 0;
+      const cacheConfigTime = cacheThemeAttributes['cache-burst'] ? new Date(cacheThemeAttributes['cache-burst']) : 0;
+      const pageConfigTime = pageThemeAttributes['cache-burst'] ? new Date(pageThemeAttributes['cache-burst']) : 0;
       if((pageConfigTime - cacheConfigTime) > 0) {
         app.updateServiceWorker && app.updateServiceWorker();
       }

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -35,8 +35,7 @@ export function checkForServiceWorkerUpdates(app, page = {}) {
   }
 
   /* Check if the config is updated and update the service worker if true */
-
-  if(window.qtVersion) {
+  else if(window && window.qtVersion) {
     const {qtVersion: {configVersion = 0} = {}} = window;
     const {config:{'theme-attributes': pageThemeAttributes = {}} = {}} = page;
     if((pageThemeAttributes['cache-burst'] || 0) > parseInt(configVersion)) {
@@ -44,6 +43,7 @@ export function checkForServiceWorkerUpdates(app, page = {}) {
       app.updateServiceWorker && app.updateServiceWorker();
     }
   }
+
 
   return page;
 }

--- a/client/impl/load-service-worker.js
+++ b/client/impl/load-service-worker.js
@@ -27,30 +27,23 @@ export function setupServiceWorkerUpdates(serviceWorkerPromise, app, store, page
     });
 }
 
-export function checkForServiceWorkerUpdates(app, page) {
-  if(page.appVersion && app.getAppVersion && app.getAppVersion() < page.appVersion) {
+export function checkForServiceWorkerUpdates(app, page = {}) {
+
+  if((page.appVersion && app.getAppVersion && app.getAppVersion() < page.appVersion)) {
     console && console.log("Updating the Service Worker");
     app.updateServiceWorker && app.updateServiceWorker();
   }
 
   /* Check if the config is updated and update the service worker if true */
 
-  caches && caches.match('/route-data.json', {'ignoreSearch': true})
-    .then((response) => {
-      if (response) {
-        return response.json()
-      }
-    })
-    .then((cachedData = {}) => {
-      const {config: {'theme-attributes': cacheThemeAttributes = {}} = {}} = cachedData;
-      const {config: {'theme-attributes': pageThemeAttributes = {}} = {}} = page;
-      const cacheConfigTime = cacheThemeAttributes['cache-burst'] ? new Date(cacheThemeAttributes['cache-burst']) : 0;
-      const pageConfigTime = pageThemeAttributes['cache-burst'] ? new Date(pageThemeAttributes['cache-burst']) : 0;
-      if((pageConfigTime - cacheConfigTime) > 0) {
-        app.updateServiceWorker && app.updateServiceWorker();
-      }
-
-    });
+  if(window.qtVersion) {
+    const {qtVersion: {configVersion = 0} = {}} = window;
+    const {config:{'theme-attributes': pageThemeAttributes = {}} = {}} = page;
+    if((pageThemeAttributes['cache-burst'] || 0) > parseInt(configVersion)) {
+      console.log(`updating service worker due to config change`);
+      app.updateServiceWorker && app.updateServiceWorker();
+    }
+  }
 
   return page;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,12 @@
         }
       }
     },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -56,6 +62,21 @@
       "requires": {
         "mime-types": "2.1.17",
         "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.7.1"
       }
     },
     "ajv": {
@@ -101,6 +122,12 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -129,6 +156,12 @@
       "requires": {
         "lodash": "4.17.4"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1008,6 +1041,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
+    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -1371,6 +1410,21 @@
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
+    "cssom": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.4"
+      }
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -1385,6 +1439,17 @@
         "assert-plus": "1.0.0"
       }
     },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1392,6 +1457,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1432,6 +1503,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
     },
     "duplexify": {
       "version": "3.5.1",
@@ -1530,10 +1610,37 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "dev": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -1626,6 +1733,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastparse": {
       "version": "1.1.1",
@@ -1900,6 +2013,15 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.3"
+      }
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -2052,6 +2174,46 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jsdom": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "5.7.1",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.4",
+        "cssstyle": "0.3.1",
+        "data-urls": "1.0.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.11.0",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.0.7",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
+        "request": "2.86.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.4",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
+      }
+    },
+    "jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -2114,6 +2276,22 @@
       "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
       "requires": {
         "colornames": "0.0.2"
+      }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-script": {
@@ -2213,6 +2391,12 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "log": {
       "version": "1.4.0",
@@ -2436,6 +2620,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.7.tgz",
+      "integrity": "sha512-VZXniaaaORAXGCNsvUNefsKRQYk8zCzQZ57jalgrpHcU70OrAzKAiN/3plYtH/VPRmZeYyUzQiYfKzcMXC1g5Q==",
       "dev": true
     },
     "nyc": {
@@ -4069,6 +4259,20 @@
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -4111,6 +4315,12 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
       }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.2",
@@ -4166,6 +4376,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "postcss": {
       "version": "6.0.21",
@@ -4355,6 +4571,12 @@
         "icss-replace-symbols": "1.1.0",
         "postcss": "6.0.21"
       }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
@@ -4710,6 +4932,17 @@
         "lodash": "4.17.4"
       }
     },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4758,6 +4991,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "0.3.0",
@@ -5000,6 +5239,12 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
       "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "text-hex": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
@@ -5036,6 +5281,23 @@
         }
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -5060,6 +5322,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.15",
@@ -5208,6 +5479,15 @@
         "extsprintf": "1.3.0"
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -5215,6 +5495,12 @@
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "webpack-manifest-plugin": {
       "version": "1.3.2",
@@ -5244,10 +5530,36 @@
         }
       }
     },
+    "whatwg-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
     },
     "winston": {
       "version": "3.0.0-rc1",
@@ -5276,6 +5588,12 @@
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-3.0.1.tgz",
       "integrity": "sha1-gAixXu9WYMT7P6CU1YzL0IUoxY0="
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "worker-farm": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
@@ -5296,6 +5614,22 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/wretch/-/wretch-1.3.1.tgz",
       "integrity": "sha512-2oZNayYKjDwhZBSk+FTt1yVnW4iNVcgmlPxbL+c6N76O+FIGiETCeN3RUaMWNauWNym52HVbul/BdKwW5SSQ9A=="
+    },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
     "history": "^4.7.2",
+    "jsdom": "11.11.0",
+    "jsdom-global": "3.0.2",
     "mocha": "^4.0.1",
     "nyc": "^11.4.1",
     "supertest": "^3.0.0"

--- a/server/handlers/generate-service-worker.js
+++ b/server/handlers/generate-service-worker.js
@@ -5,8 +5,7 @@ function generateServiceWorker(req, res, next, {config, generateRoutes, appVersi
       assetPath: assetHelper.assetPath,
       hostname: req.hostname,
       assetHash: assetHelper.assetHash,
-      routes: generateRoutes(config).filter(route => !route.skipPWA),
-      themeAttributes: config['config']['theme-attributes']
+      routes: generateRoutes(config).filter(route => !route.skipPWA)
     }, (err, content) => {
       // istanbul ignore if
       if(err) {

--- a/server/handlers/generate-service-worker.js
+++ b/server/handlers/generate-service-worker.js
@@ -6,6 +6,7 @@ function generateServiceWorker(req, res, next, {config, generateRoutes, appVersi
       hostname: req.hostname,
       assetHash: assetHelper.assetHash,
       routes: generateRoutes(config).filter(route => !route.skipPWA),
+      themeAttributes: config['config']['theme-attributes']
     }, (err, content) => {
       // istanbul ignore if
       if(err) {

--- a/test/unit/load-service-worker-test.js
+++ b/test/unit/load-service-worker-test.js
@@ -49,8 +49,8 @@ describe('LoadServiceWorker', function() {
 
     beforeEach(() => {
       this.jsdom = require('jsdom-global')();
-      window.qtVersion = {};
-      window.qtVersion.configVersion = 1532332716946;
+      global.qtVersion = {};
+      global.qtVersion.configVersion = 1532332716946;
     });
 
     afterEach(() => {


### PR DESCRIPTION
When a config is updated from secret mode to itsman, the service worker needs to update itself to serve the updated shell to reflect the change on the UI.

The above is done by comparing the timestamp of the uploaded configuration and that of which is set globally in the client.

- [x] Logic to update SW
- [x] Add tests