### PR TITLE
fix(customRouteHandler): Remove trailing slash if any for static pages :bug:

### DIFF
--- a/server/handlers/custom-route-handler.js
+++ b/server/handlers/custom-route-handler.js
@@ -44,7 +44,9 @@ function writeStaticPageResponse(res, url, page, result, { config, renderLayout,
 
 exports.customRouteHandler = function customRouteHandler(req, res, next, { config, client, loadData, loadErrorData, renderLayout, logError, seo, domainSlug }) {
   const url = urlLib.parse(req.url, true);
-  const path = req.params[0];
+  const path = req.params[0].endsWith('/') ?
+    req.params[0].slice(0, -1) :
+    req.params[0];
   return CustomPath.getCustomPathData(client, path)
     .then(page => {
       if(!page) {


### PR DESCRIPTION
#### Issue : 
https://ace-web.qtstage.io/about-us returns a configured static page as opposed to https://ace-web.qtstage.io/about-us/ returning a 404

#### Criteria : 
handle trailing slash if any for static pages ex : https://ace-web.qtstage.io/about-us/ and return relevant results

#### Solution : 
check if the path ends with a `/` strip if true