### PR TITLE
fix (fcm): replaced global.wretch by fetch in registerFCMTopic

### DIFF
--- a/client/impl/fcm.js
+++ b/client/impl/fcm.js
@@ -32,11 +32,18 @@ function updateToken(firebaseInstance) {
     .then(token => {
       return registerFCMTopic(token);
     })
-    .catch(() => {
+    .catch(err => {
+      console.log(err, "Could not retrieve token from firebase");
       throw new Error("Could not retrieve token from firebase");
     });
 }
 
 function registerFCMTopic(token) {
-  return global.wretch("/register-fcm-topic").post({ token: token });
+  return fetch("/register-fcm-topic", {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ token: token })
+  });
 }

--- a/client/impl/fcm.js
+++ b/client/impl/fcm.js
@@ -33,8 +33,7 @@ function updateToken(firebaseInstance) {
       return registerFCMTopic(token);
     })
     .catch(err => {
-      console.log(err, "Could not retrieve token from firebase");
-      throw new Error("Could not retrieve token from firebase");
+      throw new Error(err);
     });
 }
 


### PR DESCRIPTION
fix made to receive token from api call using **fetch**. Since **global.wretch** is not present in all existing publishers