### PR TITLE
test: setCorsHeaders unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "3.29.2",
+  "version": "3.29.3-amp-infinite-scroll.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "3.29.2",
+  "version": "3.29.3-amp-infinite-scroll.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/test/integration/amp-handler-test.js
+++ b/test/integration/amp-handler-test.js
@@ -212,7 +212,6 @@ describe("Amp infinite scroll handler", () => {
       .set("amp-same-origin", "true")
       .expect(200)
       .expect("Content-Type", /json/)
-      .expect("access-control-allow-origin", "*")
       .end((err, res) => {
         if (err) return done(err);
         const response = res.text;
@@ -228,7 +227,6 @@ describe("Amp infinite scroll handler", () => {
       .set("amp-same-origin", "true")
       .expect(200)
       .expect("Content-Type", /json/)
-      .expect("access-control-allow-origin", "*")
       .end((err, res) => {
         if (err) return done(err);
         const response = res.text;

--- a/test/integration/amp-handler-test.js
+++ b/test/integration/amp-handler-test.js
@@ -204,7 +204,7 @@ describe("Amp story page handler", () => {
 });
 
 describe("Amp infinite scroll handler", () => {
-  it("returns infinite scroll json config from story 5 onwards for same-origin requests", function (done) {
+  it("returns infinite scroll json config from story 5 onwards", function (done) {
     const app = createApp();
     const expectedJson = `{"pages":[{"image":"https://gumlet.assettype.com/pqr/heroimage.jpg?format=webp&w=250","title":"headline6","url":"/amp/story/foo.com/story-f"},{"image":"https://gumlet.assettype.com/stu/heroimage.jpg?format=webp&w=250","title":"headline7","url":"/amp/story/foo.com/story-g"}]}`;
     supertest(app)
@@ -233,63 +233,6 @@ describe("Amp infinite scroll handler", () => {
         if (err) return done(err);
         const response = res.text;
         assert.equal(expectedJson, response);
-        return done();
-      });
-  });
-  it("returns infinite scroll json config from story 5 onwards for requests coming from google CDN", function (done) {
-    const app = createApp();
-    supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=foo")
-      .set("origin", "https://www-vikatan-com.cdn.ampproject.org")
-      .expect(200)
-      .expect("Content-Type", /json/)
-      .expect(
-        "access-control-allow-origin",
-        "https://www-vikatan-com.cdn.ampproject.org"
-      )
-      .end((err, res) => {
-        if (err) return done(err);
-        return done();
-      });
-  });
-  it("returns infinite scroll json config from story 5 onwards for requests coming from bing CDN", function (done) {
-    const app = createApp();
-    supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=foo")
-      .set("origin", "https://www-vikatan-com.www.bing-amp.com")
-      .expect(200)
-      .expect("Content-Type", /json/)
-      .expect(
-        "access-control-allow-origin",
-        "https://www-vikatan-com.www.bing-amp.com"
-      )
-      .end((err, res) => {
-        if (err) return done(err);
-        return done();
-      });
-  });
-  it("returns infinite scroll json config from story 5 onwards for requests coming from subdomain", function (done) {
-    const app = createApp();
-    supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=foo")
-      .set("origin", "https://cinema.vikatan.com")
-      .expect(200)
-      .expect("Content-Type", /json/)
-      .expect("access-control-allow-origin", "https://cinema.vikatan.com")
-      .end((err, res) => {
-        if (err) return done(err);
-        return done();
-      });
-  });
-  it("Does not return amp infinite scroll config for requests coming from non-whitelosted origins", function (done) {
-    const app = createApp();
-    supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=foo")
-      .set("origin", "https://www.facebook.com")
-      .expect(401)
-      .end((err, res) => {
-        if (err) return done(err);
-        assert.equal(JSON.stringify("Unauthorized"), res.text);
         return done();
       });
   });

--- a/test/unit/amp-setcorsheaders-test.js
+++ b/test/unit/amp-setcorsheaders-test.js
@@ -37,7 +37,6 @@ describe("setCorsHeaders helper function", () => {
     supertest(app)
       .get("/test/cors/route")
       .set("amp-same-origin", "true")
-      .expect("access-control-allow-origin", "*")
       .expect(200, done);
   });
   it("sets CORS headers for requests coming from google CDN", function (done) {

--- a/test/unit/amp-setcorsheaders-test.js
+++ b/test/unit/amp-setcorsheaders-test.js
@@ -26,18 +26,24 @@ function createApp(app = express()) {
       ],
     };
     setCorsHeaders({ req, res, publisherConfig: dummyPublisherConfig });
-    if (!res.headersSent) return res.send("test");
+    if (!res.headersSent) return res.json("test");
   });
   return app;
 }
 
 describe("setCorsHeaders helper function", () => {
-  it("sets CORS headers for same-origin requests that have amp-same-origin header set", function (done) {
+  it("same-origin requests go through", function (done) {
     const app = createApp();
     supertest(app)
       .get("/test/cors/route")
       .set("amp-same-origin", "true")
-      .expect(200, done);
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal(JSON.stringify("test"), res.text);
+        return done();
+      });
   });
   it("sets CORS headers for requests coming from google CDN", function (done) {
     const app = createApp();

--- a/test/unit/amp-setcorsheaders-test.js
+++ b/test/unit/amp-setcorsheaders-test.js
@@ -1,0 +1,119 @@
+/* eslint-disable func-names */
+/* eslint-disable consistent-return */
+import supertest from "supertest";
+import { setCorsHeaders } from "../../server/amp-helpers";
+
+const express = require("express");
+const assert = require("assert");
+
+function createApp(app = express()) {
+  app.get("/test/cors/route", function (req, res) {
+    const dummyPublisherConfig = {
+      "sketches-host": "https://www.vikatan.com",
+      domains: [
+        {
+          name: "entertainment",
+          slug: "entertainment",
+          "host-url": "https://cinema.vikatan.com",
+          "beta-host-url": null,
+        },
+        {
+          name: "sports",
+          slug: "sports",
+          "host-url": "https://sports.vikatan.com",
+          "beta-host-url": null,
+        },
+      ],
+    };
+    setCorsHeaders({ req, res, publisherConfig: dummyPublisherConfig });
+    if (!res.headersSent) return res.send("test");
+  });
+  return app;
+}
+
+describe("setCorsHeaders helper function", () => {
+  it("sets CORS headers for same-origin requests that have amp-same-origin header set", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("amp-same-origin", "true")
+      .expect("access-control-allow-origin", "*")
+      .expect(200, done);
+  });
+  it("sets CORS headers for requests coming from google CDN", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://www-vikatan-com.cdn.ampproject.org")
+      .expect(
+        "access-control-allow-origin",
+        "https://www-vikatan-com.cdn.ampproject.org"
+      )
+      .expect(200, done);
+  });
+  it("sets CORS headers for requests coming from bing CDN", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://www-vikatan-com.www.bing-amp.com")
+      .expect(
+        "access-control-allow-origin",
+        "https://www-vikatan-com.www.bing-amp.com"
+      )
+      .expect(200, done);
+  });
+  it("sets CORS headers for requests coming from a valid subdomain", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://cinema.vikatan.com")
+      .expect("access-control-allow-origin", "https://cinema.vikatan.com")
+      .expect(200, done);
+  });
+  it("sets a 401 on requests originating from an invalid subdomain", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://foo.vikatan.com")
+      .expect(401)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal(JSON.stringify("Unauthorized"), res.text);
+        return done();
+      });
+  });
+  it("sets CORS headers for requests coming from a cached subdomain (Google)", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://cinema-vikatan-com.cdn.ampproject.org")
+      .expect(
+        "access-control-allow-origin",
+        "https://cinema-vikatan-com.cdn.ampproject.org"
+      )
+      .expect(200, done);
+  });
+  it("sets CORS headers for requests coming from a cached subdomain (Bing)", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://cinema-vikatan-com.www.bing-amp.com")
+      .expect(
+        "access-control-allow-origin",
+        "https://cinema-vikatan-com.www.bing-amp.com"
+      )
+      .expect(200, done);
+  });
+  it("sets a 401 on requests originating from a non-whitelisted source", function (done) {
+    const app = createApp();
+    supertest(app)
+      .get("/test/cors/route")
+      .set("origin", "https://www.facebook.com")
+      .expect(401)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal(JSON.stringify("Unauthorized"), res.text);
+        return done();
+      });
+  });
+});


### PR DESCRIPTION
https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests

we have a helper function to set CORS headers. Valid CORS requests can come from
1. google/bing CDN
2. subdomains
3. google/bing CDN of subdomains

I had missed out google/bing CDN of subdomains, so adding that to whitelist in this PR. Also, added unit tests for the setCorsHeaders helper function (since we might use it later for other stuff, not just infinite scroll)
