### PR TITLE
Provide the response(res) as params to load data() function in the app.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.5.12-passing-req-res-to-load-data.0",
+  "version": "4.5.12-passing-req-res-to-load-data.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.5.11",
+  "version": "4.5.12-passing-req-res-to-load-data.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.5.11",
+  "version": "4.5.12-passing-req-res-to-load-data.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.5.12-passing-req-res-to-load-data.0",
+  "version": "4.5.12-passing-req-res-to-load-data.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -27,7 +27,7 @@ function loadDataForIsomorphicRoute(
   loadErrorData,
   url,
   routes,
-  { otherParams, config, client, host, logError, domainSlug, res, req }
+  { otherParams, config, client, host, logError, domainSlug, res }
 ) {
   return loadDataForEachRoute().catch((error) => {
     logError(error);
@@ -43,7 +43,6 @@ function loadDataForIsomorphicRoute(
         next: abortHandler,
         domainSlug,
         res,
-        req,
       });
 
       if (result && result[ABORT_HANDLER]) continue;
@@ -265,7 +264,6 @@ exports.handleIsomorphicDataLoad = function handleIsomorphicDataLoad(
         otherParams: req.query,
         domainSlug,
         res,
-        req,
       }
     ).catch((e) => {
       logError(e);
@@ -505,7 +503,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
     loadErrorData,
     url,
     generateRoutes(config, domainSlug),
-    { config, client, logError, host: req.hostname, domainSlug, res, req }
+    { config, client, logError, host: req.hostname, domainSlug, res }
   )
     .catch((e) => {
       logError(e);


### PR DESCRIPTION
Currently we have load data function with  host , next and domainSlug in object params , i'm passing one more params to load data function in object so that the redirection can handle in here itself , instead of defining in `server/app.js` 

current malibu load data function()
`loadData(pageType, params, config, client, { host, next, domainSlug })` 
after changes this 
`loadData(pageType, params, config, client, {res,  host, next, domainSlug })` 