### PR TITLE
fix(relatedstories): Fix related stories memoize :zap:

### DIFF
--- a/server/amp/handlers/story-page.js
+++ b/server/amp/handlers/story-page.js
@@ -31,7 +31,7 @@ async function ampStoryPageHandler(
     const { ampifyStory } = ampLibrary;
     // eslint-disable-next-line no-return-await
     const ampConfig = await config.memoizeAsync(
-      "amp-config",
+      `ampConfig_${config["publisher-id"]}`,
       async () => await AmpConfig.getAmpConfig(client)
     );
     const slug = String(0);


### PR DESCRIPTION
# Description

Related stories was cached with a duplicate key hence the same related stories was served for all publishers.