### PR TITLE
fix(AMP): Implement AMP Story Page Handler ⚡ 

### DIFF
--- a/server/amp/handlers/story-page.js
+++ b/server/amp/handlers/story-page.js
@@ -1,6 +1,7 @@
 const urlLib = require("url");
 const set = require("lodash/set");
 const get = require("lodash/get");
+const cloneDeep = require("lodash/cloneDeep");
 const merge = require("lodash/merge");
 const { Story, AmpConfig } = require("../../impl/api-client-impl");
 const {
@@ -34,10 +35,11 @@ async function ampStoryPageHandler(
     cdnProvider = null,
     ampLibrary = require("@quintype/amp"),
     additionalConfig = require("../../publisher-config"),
-    ...opts
+    ...rest
   }
 ) {
   try {
+    const opts = cloneDeep(rest);
     const domainSpecificOpts = getDomainSpecificOpts(opts, domainSlug);
     const url = urlLib.parse(req.url, true);
     const { ampifyStory } = ampLibrary;
@@ -46,8 +48,7 @@ async function ampStoryPageHandler(
       "amp-config",
       async () => await AmpConfig.getAmpConfig(client)
     );
-    const slug = String(0);
-    const story = await Story.getStoryBySlug(client, req.params[slug]);
+    const story = await Story.getStoryBySlug(client, req.params["0"]);
     let relatedStoriesCollection;
     let relatedStories = [];
 

--- a/test/unit/amp/amp-get-domain-specific-opts.js
+++ b/test/unit/amp/amp-get-domain-specific-opts.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { getDomainSpecificOpts } = require("../../server/amp/helpers");
+const { getDomainSpecificOpts } = require("../../../server/amp/helpers");
 
 describe("getDomainSpecificOpts helper function", function () {
   const opts = {

--- a/test/unit/amp/amp-setcorsheaders-test.js
+++ b/test/unit/amp/amp-setcorsheaders-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable func-names */
 /* eslint-disable consistent-return */
 import supertest from "supertest";
-import { setCorsHeaders } from "../../server/amp/helpers";
+import { setCorsHeaders } from "../../../server/amp/helpers";
 
 const express = require("express");
 const assert = require("assert");

--- a/test/unit/amp/amp-story-page-handler.js
+++ b/test/unit/amp/amp-story-page-handler.js
@@ -1,0 +1,73 @@
+/* eslint-disable func-names */
+
+const assert = require("assert");
+const cloneDeep = require("lodash/cloneDeep");
+const { ampStoryPageHandler } = require("../../../server/amp/handlers");
+
+const ampConfig = {
+  "related-collection-id": "related-stories-collection",
+};
+
+function getClientStub() {
+  return {
+    getHostname: () => "demo.quintype.io",
+    getConfig: () =>
+      Promise.resolve({
+        memoizeAsync: (key, fn) => Promise.resolve(ampConfig),
+      }),
+    getStoryBySlug: (slug, params) =>
+      Promise.resolve({
+        story: {
+          "story-content-id": 111,
+          heading: "Dogecoin surges to $10 billion",
+        },
+      }),
+    getCollectionBySlug: (slug) => {
+      switch (slug) {
+        case "related-stories-collection":
+          return Promise.resolve({
+            items: [{ type: "story", id: 123 }],
+          });
+        default:
+          return Promise.resolve({});
+      }
+    },
+  };
+}
+
+describe("ampStoryPageHandler", function () {
+  it("Should not mutate opts", async function () {
+    const dummyOpts = {
+      featureConfig: {
+        lorem: {
+          ipsum: "abc",
+        },
+      },
+    };
+    const dummyOptsClone = cloneDeep(dummyOpts);
+    const req = {
+      url: "foo",
+      params: "/story/slug",
+    };
+    const res = {
+      redirect: () => null,
+      set: () => null,
+      send: () => null,
+    };
+    const next = () => null;
+    const config = {
+      memoizeAsync: (key, fn) => {
+        return Promise.resolve(ampConfig);
+      },
+    };
+    await ampStoryPageHandler(req, res, next, {
+      client: getClientStub(),
+      config,
+      domainSlug: null,
+      seo: "",
+      additionalConfig: "something",
+      ...dummyOpts,
+    });
+    assert.deepStrictEqual(dummyOptsClone, dummyOpts);
+  });
+});


### PR DESCRIPTION
# Description

Found that `ampStoryPageHandler` was mutating the `opts` object passed to it. This wasn't a problem for custom publishers since `opts` comes from publisher app and will remain same. But in case of ahead it's a problem since opts belonging to one ahead publisher was being passed to another ahead publisher.
Because of this, things like related stories etc. of one ahead publisher were being shown to a different ahead publisher. Bad!

Fixes # (issue-reference)

https://github.com/quintype/ace-planning/issues/259

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Wrote a test to check that `ampStoryPageHandler` no longer mutates opts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
