### PR TITLE
fix: change routing for visualStories

### DIFF
--- a/server/amp/handlers/index.js
+++ b/server/amp/handlers/index.js
@@ -1,9 +1,11 @@
 const { ampStoryPageHandler } = require("./story-page");
 const { storyPageInfiniteScrollHandler } = require("./infinite-scroll");
 const { bookendHandler } = require("./visual-stories-bookend");
+const { visualStoryHandler } = require("./visual-story");
 
 module.exports = {
   ampStoryPageHandler,
   storyPageInfiniteScrollHandler,
   bookendHandler,
+  visualStoryHandler,
 };

--- a/server/amp/handlers/visual-story.js
+++ b/server/amp/handlers/visual-story.js
@@ -1,0 +1,14 @@
+/* eslint-disable global-require */
+const { Story } = require("../../impl/api-client-impl");
+const { ampStoryPageHandler } = require("./story-page");
+
+async function visualStoryHandler(req, res, next, { client, ...rest }) {
+  const story = await Story.getStoryBySlug(client, req.params.storySlug);
+  if (!story || story["story-template"] !== "visual-story") return next();
+  return ampStoryPageHandler(req, res, next, {
+    client,
+    ...rest,
+  });
+}
+
+module.exports = { visualStoryHandler };

--- a/server/routes.js
+++ b/server/routes.js
@@ -587,8 +587,10 @@ exports.mountQuintypeAt = function (app, mountAt) {
 /**
  * *ampRoutes* handles all the amp page routes using the *[@quintype/amp](https://developers.quintype.com/quintype-node-amp)* library
  * routes matched:
- * GET - "/amp/story/:slug"* returns amp story page
+ * GET - "/amp/story/*" returns amp story page
  * GET - "/amp/api/v1/amp-infinite-scroll" returns the infinite scroll config JSON. Passed to <amp-next-page> component's `src` attribute
+ * GET - "/amp/api/v1/bookend.json" returns visual story bookend JSON
+ * GET - "/*\/:storySlug" [Should come before isomorphicRoutes] matches ALL story routes (including non-AMP). Checks if it's a visual story. If yes, call ampStoryPageHandler else call next handler.
  *
  * @param {Express} app Express app to add the routes to
  * @param {Object} opts Options object used to configure amp. Passing this is optional
@@ -604,6 +606,7 @@ exports.ampRoutes = (app, opts = {}) => {
     ampStoryPageHandler,
     storyPageInfiniteScrollHandler,
     bookendHandler,
+    visualStoryHandler,
   } = require("./amp/handlers");
 
   getWithConfig(app, "/amp/story/*", ampStoryPageHandler, opts);
@@ -614,5 +617,5 @@ exports.ampRoutes = (app, opts = {}) => {
     opts
   );
   getWithConfig(app, "/amp/api/v1/bookend.json", bookendHandler, opts);
-  getWithConfig(app, "/ampstories/*", ampStoryPageHandler, opts);
-};
+  getWithConfig(app, "/*/:storySlug", visualStoryHandler, opts);
+};;


### PR DESCRIPTION
https://github.com/quintype/ace-planning/issues/221

- `visualStoryHandler` is run for route -`/*/:storySlug` (all AMP and non-AMP stories)
- in `visualStoryHandler`, check if it's a visual story. If yes, render. Else call `next()` so that isomorphicRoutes will catch it 

Questions:
- how to handle AJAX navigation?
- we're calling story API inside `visualStoryHandler`. Will this impact server response time much? 