### PR TITLE
Amp move is amp supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2213,9 +2213,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.3.1.tgz",
-      "integrity": "sha512-3UiIIi42N+VnKojJvHIypQl//QoKV2awhoCXBNv4LGZK9H9u1Gocyp0tA7ezPWb4yrnZa+GU/8mM/QKQbGqQug==",
+      "version": "2.4.0-move-isAmpSupported.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.0-move-isAmpSupported.0.tgz",
+      "integrity": "sha512-fepkrV7YCR2eXUzxzOlSC7SCSbH/evkR4XV27GbmzkN+CBIHTkw0mF1n30sjNFS6LcE9JD4PwvH3+bUwbCggwQ==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",
@@ -20323,16 +20323,16 @@
       }
     },
     "styled-components": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
-      "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.3.tgz",
+      "integrity": "sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
         "@emotion/is-prop-valid": "^0.8.8",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1",
+        "babel-plugin-styled-components": ">= 1.12.0",
         "css-to-react-native": "^3.0.0",
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2213,9 +2213,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.0-move-isAmpSupported.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.0-move-isAmpSupported.1.tgz",
-      "integrity": "sha512-CNRoqoojOp6y9rBgrffegdq+qFxRgbP7htf6B4NvlewKNuPUaHgW093x0T4lh8qWcwWx/7ns74K3dogHtPFCAA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.0.tgz",
+      "integrity": "sha512-WUFZja04abofsX6GGj8hFREaZntQih0RmTKxTv+3oSsY7TMK/ks1YILBgFNtAYVnLbZQJo3U2K1R89KhCTTxDA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.3-amp-move-isAmpSupported.1",
+  "version": "4.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2-amp-move-isAmpSupported.0",
+  "version": "4.13.2-amp-move-isAmpSupported.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2-amp-move-isAmpSupported.1",
+  "version": "4.13.3-amp-move-isAmpSupported.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.1",
+  "version": "4.13.2-amp-move-isAmpSupported.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2213,9 +2213,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.0-move-isAmpSupported.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.0-move-isAmpSupported.0.tgz",
-      "integrity": "sha512-fepkrV7YCR2eXUzxzOlSC7SCSbH/evkR4XV27GbmzkN+CBIHTkw0mF1n30sjNFS6LcE9JD4PwvH3+bUwbCggwQ==",
+      "version": "2.4.0-move-isAmpSupported.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.0-move-isAmpSupported.1.tgz",
+      "integrity": "sha512-CNRoqoojOp6y9rBgrffegdq+qFxRgbP7htf6B4NvlewKNuPUaHgW093x0T4lh8qWcwWx/7ns74K3dogHtPFCAA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
-    "@quintype/amp": "^2.3.1",
+    "@quintype/amp": "^2.4.0-move-isAmpSupported.0",
     "@quintype/backend": "^1.3.2",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
-    "@quintype/amp": "^2.4.0-move-isAmpSupported.0",
+    "@quintype/amp": "^2.4.0-move-isAmpSupported.1",
     "@quintype/backend": "^1.3.2",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2-amp-move-isAmpSupported.0",
+  "version": "4.13.2-amp-move-isAmpSupported.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.3-amp-move-isAmpSupported.1",
+  "version": "4.13.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.1",
+  "version": "4.13.2-amp-move-isAmpSupported.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
-    "@quintype/amp": "^2.4.0-move-isAmpSupported.1",
+    "@quintype/amp": "^2.4.0",
     "@quintype/backend": "^1.3.2",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2-amp-move-isAmpSupported.1",
+  "version": "4.13.3-amp-move-isAmpSupported.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/test/data/amp-test-data.js
+++ b/test/data/amp-test-data.js
@@ -1,0 +1,997 @@
+export const getTextStory = (opts = {}) => {
+  const story = {
+    "updated-at": 1581503848382,
+    seo: {
+      "meta-keywords": [
+        "LSAC",
+        "Law School",
+        "legal Education",
+        "Lawyers",
+        "Advocates",
+        "India",
+        "Law",
+      ],
+      "meta-title": "Empowering India’s Future Lawyers and Leaders",
+      "meta-description":
+        "#Sponsored: New milestones and initiatives mark LSAC’s ongoing efforts to increase access to legal education in India. - Bar & Bench ",
+      "claim-reviews": {
+        story: null,
+      },
+    },
+    "assignee-id": 708282,
+    "author-name": "Ravi Kanth",
+    tags: [
+      {
+        id: 2038546,
+        name: "LSAC",
+        "meta-description": null,
+        "meta-title": null,
+        slug: "lsac",
+        "tag-type": "Tag",
+      },
+    ],
+    headline: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+    "storyline-id": null,
+    votes: {},
+    "story-content-id": "7f3d5bdb-ec52-4047-ac0d-df4036ec974b",
+    slug: "news/empowering-indias-future-lawyers-and-leaders",
+    "linked-stories": {
+      "a7a06a3f-8d9a-450c-8eaa-387b7c8c6323": {
+        "author-name": "Ravi Kanth",
+        headline:
+          "LSAC Launches New Initiatives to Support Law School Enrollment Efforts in India",
+        "story-content-id": "a7a06a3f-8d9a-450c-8eaa-387b7c8c6323",
+        slug:
+          "news/lsac-launches-new-initiatives-to-support-law-school-enrollment-efforts-in-india",
+        sections: [
+          {
+            "domain-slug": null,
+            slug: "news",
+            name: "News",
+            "section-url": "https://www.barandbench.com/news",
+            id: 14017,
+            "parent-id": null,
+            "display-name": "News",
+            collection: {
+              slug: "news",
+              name: "News",
+              id: 29911,
+            },
+            data: null,
+          },
+          {
+            "domain-slug": null,
+            slug: "others",
+            name: "Others",
+            "section-url": "https://www.barandbench.com/others",
+            id: 14026,
+            "parent-id": null,
+            "display-name": "Others",
+            collection: {
+              slug: "others",
+              name: "Others",
+              id: 29920,
+            },
+            data: null,
+          },
+        ],
+        "hero-image-metadata": {
+          width: 5472,
+          height: 3648,
+          "mime-type": "image/jpeg",
+          "file-size": 6127839,
+          "file-name":
+            "LSAC Launches New Initiatives to Support Law School Enrollment Efforts in India.JPG",
+          "focus-point": [2609, 1102],
+        },
+        "hero-image-s3-key":
+          "barandbench/2020-01/0329b37d-5ec6-4bb4-b16f-2009bbaf13c9/LSAC_Launches_New_Initiatives_to_Support_Law_School_Enrollment_Efforts_in_India.JPG",
+        url:
+          "https://www.barandbench.com/news/lsac-launches-new-initiatives-to-support-law-school-enrollment-efforts-in-india",
+        "content-updated-at": 1579162728757,
+        "author-id": 708282,
+        "first-published-at": 1579162728583,
+        authors: [
+          {
+            id: 708282,
+            name: "Ravi Kanth",
+            slug: "ravi-kanth",
+            "avatar-url":
+              "https://images.assettype.com/barandbench/2020-01/82d5c350-9791-4cdb-88d5-f52b2d98a4ab/Bar_and_Bench_Icon_Purple.png",
+            "avatar-s3-key":
+              "barandbench/2020-01/82d5c350-9791-4cdb-88d5-f52b2d98a4ab/Bar_and_Bench_Icon_Purple.png",
+            "twitter-handle": null,
+            bio: null,
+            "contributor-role": null,
+          },
+        ],
+      },
+    },
+    "last-published-at": 1581503851412,
+    subheadline:
+      "New milestones and initiatives mark LSAC’s ongoing efforts to increase access to legal education in India",
+    alternative: {},
+    sections: [
+      {
+        "domain-slug": null,
+        slug: "news",
+        name: "News",
+        "section-url": "https://www.barandbench.com/news",
+        id: 14017,
+        "parent-id": null,
+        "display-name": "News",
+        collection: {
+          slug: "news",
+          name: "News",
+          id: 29911,
+        },
+        data: null,
+      },
+    ],
+    "read-time": 5,
+    "access-level-value": null,
+    "content-created-at": 1581326633010,
+    "owner-name": "Ravi Kanth",
+    "custom-slug": "Empowering India’s Future Lawyers and Leaders",
+    "push-notification": null,
+    "publisher-id": 829,
+    "hero-image-metadata": {
+      width: 2550,
+      height: 1162,
+      "mime-type": "image/jpeg",
+      "file-size": 185634,
+      "file-name": "Discover_Law_Logo_1.jpg",
+      "focus-point": [1275, 581],
+    },
+    comments: null,
+    "word-count": 1143,
+    entities: {},
+    "published-at": 1581503851412,
+    "is-live-blog": false,
+    "breaking-news-linked-story-id": null,
+    "storyline-title": null,
+    summary: null,
+    "push-notification-title": null,
+    "external-id": null,
+    "canonical-url": null,
+    "is-amp-supported": true,
+    autotags: [],
+    "linked-entities": [],
+    status: "published",
+    "hero-image-attribution": "Create",
+    "bullet-type": "123",
+    id: "7f3d5bdb-ec52-4047-ac0d-df4036ec974b",
+    "hero-image-s3-key":
+      "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+    contributors: null,
+    "associated-series-collection-ids": [],
+    cards: [
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
+            type: "text",
+            "family-id": "e9e12f9f-8b9f-4b93-a8c8-83c7b278000f",
+            title: "",
+            id: "9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>In India today, the legal profession is growing in lockstep with one of the world’s most dynamic economies. It’s no surprise then— that in terms of absolute numbers— India’s legal profession is the world’s second largest, with over 1.4 million enrolled lawyers in legal practices nationwide.</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "efaf78de-c90b-4d15-b040-c84ebb29cabf",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
+        "content-id": "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/b1ac6dd1-cc56-41cf-88c6-faba75ac8b2f",
+            type: "text",
+            "family-id": "d185fd3f-015c-4d66-831a-013fa26125f0",
+            title: "",
+            id: "b1ac6dd1-cc56-41cf-88c6-faba75ac8b2f",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>In India today, the legal profession is growing in lockstep with one of the world’s most dynamic economies. It’s no surprise then— that in terms of absolute numbers— India’s legal profession is the world’s second largest, with over 1.4 million enrolled lawyers in legal practices nationwide.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/8431a53b-7695-424c-bc61-9aff42c4c85a",
+            type: "text",
+            "family-id": "8798aaa5-3da6-41c1-bdcf-54b3d5fac783",
+            title: "",
+            id: "8431a53b-7695-424c-bc61-9aff42c4c85a",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>There are around 1,200 law schools in India currently, with close to 80,000 enrolments taking place every year. With increasing globalization and constant policy reforms in India, the demand for legal services is higher than ever before.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/214b9ffa-ac5b-4cfd-baac-7696a9f9fa1e",
+            type: "text",
+            "family-id": "3bc6b435-c86d-4774-8116-5f5512747068",
+            title: "",
+            id: "214b9ffa-ac5b-4cfd-baac-7696a9f9fa1e",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>The Law School Admission Council (LSAC) has been fortunate to play a small part toward meeting this increased demand for legal education in India, as the country surges its efforts toward providing universal access to justice. LSAC provides some of its key services and products to Indian law colleges and law aspirants, including the LSAT—India—an entrance test specially created for the Indian legal education system— for high school students who want to apply to law schools.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/c693c1ec-ec5a-494c-931a-8f92e6957844",
+            type: "text",
+            "family-id": "0e5da403-7022-4c42-addf-f5a7dc8d9134",
+            title: "",
+            id: "c693c1ec-ec5a-494c-931a-8f92e6957844",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>LSAC’s mission in India aligns with its larger global goal of improving access to legal education and adding to the diversity of the legal profession. As LSAC furthers its commitment to build a stronger legal education and professional community across India, it continues to launch initiatives in India that take this mission forward and support law school aspirants on their enrollment journeys.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/6c98ba9e-0224-4cba-97d0-83b44e551080/element/6840b851-dce3-43cf-b346-e466a1be3b70",
+            type: "composite",
+            "family-id": "cbfd49db-f890-42e3-a964-665d41f77a82",
+            "story-elements": [
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1240,
+                  height: 698,
+                  "focus-point": [620, 349],
+                },
+                type: "image",
+                "family-id": "95db8c7b-0658-418a-b003-348d31882df8",
+                "image-attribution": "a man saying out",
+                title: "out !!!!!!",
+                id: "e6b487d3-2114-4dac-81e8-678bd847c55e",
+                "image-s3-key":
+                  "ace/2020-05/7270e0ef-2e16-4848-8be4-4de481d20bfb/reuters_spain_la_liga_06Dec19.JPG",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 3037,
+                  height: 1920,
+                  "focus-point": [1519, 960],
+                },
+                type: "image",
+                "family-id": "adaf9d7c-ce22-4a99-929f-e86438ccbefc",
+                "image-attribution": "football",
+                title: "football",
+                id: "bbc046b4-bb82-42cc-83a0-c7ecccdd8d9b",
+                "image-s3-key":
+                  "ace/2020-05/a9d04bce-56a1-4dea-8694-6e291db7a529/LEWANDOW059746243_LR2EB9M1I218R_RTRMADP_3_GERMNY_SOCCER_1_.JPG",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1280,
+                  height: 720,
+                  "focus-point": [640, 360],
+                },
+                type: "image",
+                "family-id": "fbc7e8a8-7271-42b7-9fe4-782b08b972bd",
+                "image-attribution": "Buildings",
+                title: "Huge Buildings",
+                id: "6ee8af2b-cb2d-4579-9022-3cc8a7045a5d",
+                "image-s3-key":
+                  "ace/2020-05/097d3bf3-693e-43af-901f-d8458aae1343/Durham_Austin_iStock.jpg",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1484,
+                  height: 835,
+                  "focus-point": [742, 418],
+                },
+                type: "image",
+                "family-id": "f0d9b52c-94b9-445a-b882-e35c0790fa85",
+                "image-attribution": "",
+                title: "Wallpaper",
+                id: "bfdf590b-3097-481f-81c6-e5288b8429a7",
+                "image-s3-key":
+                  "ace/2020-05/35544a89-4eea-4040-973b-450b7194f1bc/JGYSQ7JERZBZVIBL7RHVOXSKQI.png",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1140,
+                  height: 641,
+                  "focus-point": [570, 321],
+                },
+                type: "image",
+                "family-id": "ca763477-e17b-4360-ae05-4dd6123e9586",
+                "image-attribution": "",
+                title: "Flag",
+                id: "0acd7945-3440-48a2-b47c-2b22830bd7b4",
+                "image-s3-key":
+                  "ace/2020-05/c03eeadb-54f8-418a-ad34-6c3e8bee0004/14a3c7aa_791a_4ccf_bf0d_a1532c508c46_1140x641.jpg",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 5200,
+                  height: 3472,
+                  "focus-point": [2652, 1487],
+                },
+                type: "image",
+                "family-id": "57e1a187-e5f2-4674-8038-bd3ae85b2d77",
+                "image-attribution": "",
+                title: "",
+                id: "e35ff882-1dbd-41d7-b59d-f141bd595b75",
+                "image-s3-key":
+                  "ace/2020-05/ea17ec96-81cf-435f-97c6-bdf3fcc33cd8/2020_05_10T220259Z_1240337357_RC2ULG9IPO5H_RTRMADP_3_HEALTH_CORONAVIRUS_BRITAIN_JOHNSON.JPG",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1440,
+                  height: 960,
+                  "focus-point": [720, 480],
+                },
+                type: "image",
+                "family-id": "92dc70ed-a851-404e-9232-98d86e4cc923",
+                "image-attribution": "",
+                title: "",
+                id: "79f2bad2-d299-4f01-9394-1d12009f82a5",
+                "image-s3-key":
+                  "ace/2020-05/6451e3d3-8e7e-41bb-a7fa-26df0018056d/BJCEPXUQVII6VKOAOO4TIIWWSE.jpg",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1140,
+                  height: 641,
+                  "focus-point": [570, 321],
+                },
+                type: "image",
+                "family-id": "76c46e73-2fd2-44fb-b8da-9af41c7cb129",
+                "image-attribution": "",
+                title: "",
+                id: "02d71172-6324-4894-a4ed-95f1d47aa18f",
+                "image-s3-key":
+                  "ace/2020-05/d233ded8-9e98-4156-a2c6-43b97256164d/7e2b0e40_50b4_4d54_b550_7a7662b0842f_1140x641.jpg",
+                metadata: {},
+                subtype: null,
+              },
+              {
+                description: "",
+                "image-metadata": {
+                  width: 1400,
+                  height: 787,
+                  "focus-point": [700, 394],
+                },
+                type: "image",
+                "family-id": "997f9133-d6a4-4f67-bea6-f3da11072737",
+                "image-attribution": "",
+                title: "",
+                id: "56137c4f-f6c5-4362-a978-f4fd066c0dc1",
+                "image-s3-key":
+                  "ace/2020-05/59d8f44e-153a-41d1-a002-db0ed876327c/gettyimages_1211277548_wide_7def4a4c352e1ec820cd8a0384526a847797b67d.jpg",
+                metadata: {},
+                subtype: null,
+              },
+            ],
+            title: "",
+            id: "6840b851-dce3-43cf-b346-e466a1be3b70",
+            metadata: {
+              type: "gallery",
+            },
+            subtype: "image-gallery",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/2373433c-557d-48fb-8b32-0f2bdd65df78",
+            type: "text",
+            "family-id": "9b0816a1-de95-4048-bc86-2979911bcc86",
+            title: "",
+            id: "2373433c-557d-48fb-8b32-0f2bdd65df78",
+            metadata: {
+              "linked-story-id": "a7a06a3f-8d9a-450c-8eaa-387b7c8c6323",
+              "linked-story": {
+                headline:
+                  "LSAC Launches New Initiatives to Support Law School Enrollment Efforts in India",
+                "story-content-id": "a7a06a3f-8d9a-450c-8eaa-387b7c8c6323",
+                "highlighted-text": "",
+                id: "a7a06a3f-8d9a-450c-8eaa-387b7c8c6323",
+                "highlighted-headline": null,
+              },
+            },
+            subtype: "also-read",
+            text:
+              "LSAC Launches New Initiatives to Support Law School Enrollment Efforts in India",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "6796e0ce-6100-4bd9-b0ed-92e547358525",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "817da877-00f4-434f-a325-8e53092b6a01",
+        "content-id": "817da877-00f4-434f-a325-8e53092b6a01",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/026cb0db-db71-40b5-8062-666ccf3aba09",
+            type: "text",
+            "family-id": "52de5a78-aa3a-4985-a46c-09baaf01c7b8",
+            title: "",
+            id: "026cb0db-db71-40b5-8062-666ccf3aba09",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p><strong>LSAT—India: The first step toward a career in law</strong></p>",
+          },
+          {
+            description: "",
+            "image-metadata": {
+              width: 700,
+              height: 350,
+              "mime-type": "image/jpeg",
+              "file-size": 112943,
+              "file-name": "R Banumathi, AS Bopanna and Hrishikesh Roy.jpg",
+            },
+            "page-url":
+              "/story/062f7847-5029-4062-9456-e3797d28f6c3/element/e7b80c61-3745-48ac-9fdf-f5c3af5e24f3",
+            type: "image",
+            "family-id": "ae0091ce-07f0-4b59-8367-07c08dde7582",
+            "image-attribution": "",
+            title:
+              "The judgment was delivered by a three-judge Bench of Justices R Banumathi, AS Bopanna and Hrishikesh Roy",
+            id: "e7b80c61-3745-48ac-9fdf-f5c3af5e24f3",
+            "image-s3-key":
+              "barandbench/2020-03/4565d24e-e4ac-413b-a462-8d698ab4b742/R_Banumathi__AS_Bopanna_and_Hrishikesh_Roy.jpg",
+            metadata: {},
+            subtype: null,
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/f03d3680-423f-4b5b-b2e1-3ca931b60350",
+            type: "text",
+            "family-id": "d6ac182d-d65d-436b-8d3d-277bbee7fcba",
+            title: "",
+            id: "f03d3680-423f-4b5b-b2e1-3ca931b60350",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>LSAC has been helping law schools in various countries evaluate the critical thinking skills of their applicants for more than 70 years. The LSAT was developed in the 1940s in response to a proposal from a law school admissions director seeking a test with a high predictive value for success in law schools. In India, this spring will mark the 12th anniversary of the Law School Admission Council offering the LSAT—India, a standardized test that measures skills that are considered essential for success in law school. The test has grown in size and reputation since its introduction and over the years, there has been an increasing recognition of the unique value it brings to law college admissions in India.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/05066b94-784b-4913-971b-c01a1bcfb43d/element/19d96101-04b2-400a-ab95-e7362280d8a1",
+            type: "text",
+            "family-id": "5f761f27-4721-459f-8ecd-733021d8d2ea",
+            title: "",
+            id: "19d96101-04b2-400a-ab95-e7362280d8a1",
+            metadata: {
+              content:
+                "In general—and this is a good P.S.A. reminder for everyone—if you are symptomatic, you are supposed to stay home for seven days, or three days past whenever your symptoms resolve, whichever one of those is longest.",
+            },
+            subtype: "blurb",
+            text:
+              "<blockquote>In general—and this is a good P.S.A. reminder for everyone—if you are symptomatic, you are supposed to stay home for seven days, or three days past whenever your symptoms resolve, whichever one of those is longest.</blockquote>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/5da487aa-a176-4f43-a130-c247555c314b",
+            type: "text",
+            "family-id": "a1132e61-d313-41d3-8528-acd5651f3b54",
+            title: "",
+            id: "5da487aa-a176-4f43-a130-c247555c314b",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>Today, the LSAT—India is one of the leading entrance tests for undergraduate and postgraduate law programmes in India. Currently, many Indian law colleges accept the LSAT—India, and the number of students taking the test continues to increase every year. LSAC recently announced that the next LSAT—India exam will be conducted on 17 May 2020.</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "95c0bff7-36f0-45f7-b703-d8238b2361c6",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "71a162dd-d95c-4215-b4c7-7a0986e57076",
+        "content-id": "71a162dd-d95c-4215-b4c7-7a0986e57076",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/c38806bb-5c0e-4f65-aa3c-756e17a1475d",
+            type: "text",
+            "family-id": "ae1cd566-f82a-43d1-99a2-989216aa81be",
+            title: "",
+            id: "c38806bb-5c0e-4f65-aa3c-756e17a1475d",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p><strong>A New Website: For Test Prep and More</strong></p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/dbe4b190-8df9-40bd-8b42-591914d1d080",
+            type: "text",
+            "family-id": "d0f22d83-1c8c-4047-9241-a3c822967785",
+            title: "",
+            id: "dbe4b190-8df9-40bd-8b42-591914d1d080",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>In the final quarter of 2019, through its newly formed subsidiary company—LSAC Global India—LSAC launched a new website (DiscoverLaw.in) to give individuals seeking to study law in India a real-world idea of what it’s like to apply to law school, attend law school, and pursue a career in law.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/05066b94-784b-4913-971b-c01a1bcfb43d/element/40f27611-f0d0-4e4d-853a-f36c595ee21f",
+            type: "text",
+            "family-id": "0668dc6d-ffea-45a6-8531-5403fdf0a8e8",
+            title: "",
+            id: "40f27611-f0d0-4e4d-853a-f36c595ee21f",
+            metadata: {},
+            subtype: "question",
+            text:
+              "<p><strong>You have a patient on Rikers who is older than ninety?</strong></p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/4154e5bb-3261-42a5-9835-d9313c3bc61b",
+            type: "text",
+            "family-id": "d1607fc9-b490-4a9d-94f7-19fe476a614e",
+            title: "",
+            id: "4154e5bb-3261-42a5-9835-d9313c3bc61b",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>Through the website, law school aspirants can learn about the various facets of the legal profession, interact with practising lawyers, and connect with current and former law school students. They can stay updated on LSAC-hosted events such as open-house-style recruitment events that make it easy for potential applicants to research law schools on a more personal level.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/94875e01-39bf-4a85-851f-78ab54c00b55",
+            type: "text",
+            "family-id": "a92abf25-75d5-4a90-ad06-10413af57829",
+            title: "",
+            id: "94875e01-39bf-4a85-851f-78ab54c00b55",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>DiscoverLaw.in is also an excellent resource for information about the LSAT—India. Law aspirants can obtain LSAT—India prep materials, including some free copies of past LSAT—India exams. In addition, the site features information about law colleges that accept LSAT—India test scores.</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "f34aa283-4947-4567-bbcd-55ee401d524a",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "72eebe56-89e2-4d1c-88fd-171791018136",
+        "content-id": "72eebe56-89e2-4d1c-88fd-171791018136",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/5526c088-4576-4929-b1a6-6dbf94e3cac6",
+            type: "text",
+            "family-id": "2979892d-a6c8-42a3-8457-c59a82bae966",
+            title: "",
+            id: "5526c088-4576-4929-b1a6-6dbf94e3cac6",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p><strong>Law College Forum: Providing in-person opportunities</strong></p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/9e721a4f-0928-4041-a58f-3fcc0b0a2659",
+            type: "text",
+            "family-id": "19071f70-76a5-4997-8f2c-b0733883d0a8",
+            title: "",
+            id: "9e721a4f-0928-4041-a58f-3fcc0b0a2659",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>Building on LSAC’s expertise in planning education awareness events across the U.S. and Canada, LSAC Global India recently coordinated its inaugural event in India on December 6, in collaboration with LSAC. The Law College Forum — much like LSAC’s Law School Forums — was an open-house-style recruitment event for law schools to meet with prospective students on a more personal level.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/66e4dd21-baa1-4cda-a877-f9d682a2c82b",
+            type: "text",
+            "family-id": "0d5699f2-7838-40ea-a1b0-c056f59f5266",
+            title: "",
+            id: "66e4dd21-baa1-4cda-a877-f9d682a2c82b",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>This particular event, held in New Delhi in December 2019, was designed for high school students who are interested in learning more about 5-year integrated law program​s in law colleges in India and their admission process, and legal professionals and current law graduates in India who are looking to pursue an LL.M degree and ​other graduate law programs in the U.S. and Canada.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/fa98d95a-599a-4faf-82eb-6b592557be21",
+            type: "text",
+            "family-id": "535e14a4-2a0e-4401-9ffe-9f86338bb215",
+            title: "",
+            id: "fa98d95a-599a-4faf-82eb-6b592557be21",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>Twenty law schools from the US were represented at the event, and more than 600 law aspirants came to attend workshops and meet with the law colleges. Attendees could attend panels and workshops, connect with law college representatives from prestigious law schools and universities in India, Canada and the United States, members of alumni networks of LSAT—India associated colleges, and hear key note addresses by reputed legal professionals and eminent thought leaders in higher education.</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "ffc21773-e76b-46c0-9a5e-cc8517c3ed45",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "78c96dd0-55da-4bdb-b5e8-1d5c500656ea",
+        "content-id": "78c96dd0-55da-4bdb-b5e8-1d5c500656ea",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/163d8125-ecdf-4584-baff-5b7514b8bd2a",
+            type: "text",
+            "family-id": "3f8e2cb8-4c49-45fc-b4c0-84d7581a77f6",
+            title: "",
+            id: "163d8125-ecdf-4584-baff-5b7514b8bd2a",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p><strong>Honoring a Legacy: Basheer Access To Justice Scholarship</strong></p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/e4e8070b-0f37-467b-8588-62ac0b215242",
+            type: "text",
+            "family-id": "9667974f-dfd9-4689-86bc-1dda54c32521",
+            title: "",
+            id: "e4e8070b-0f37-467b-8588-62ac0b215242",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>In India, it has been LSAC’s privilege to collaborate with some truly remarkable Indian lawyers, as part of its larger effort to help map the future of India’s legal system and provide the legal and policy frameworks to ensure the growth of the world’s largest democracy. Last year, we lost, we lost one of our dearest friends in the legal community—Prof. Shamnad Basheer. He was one of the most influential lawyers and pioneering academics in India, and an incredible visionary.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/0d780c75-78db-4642-9bd9-780418806fc5",
+            type: "text",
+            "family-id": "b8fef4a3-9c9b-4655-9e74-8bb9d10c3552",
+            title: "",
+            id: "0d780c75-78db-4642-9bd9-780418806fc5",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>We are honoring his memory by instating the Basheer Access To Justice Scholarship. This scholarship will provide access to deserving students from traditionally underrepresented communities who embody the values, grit, and tenacity that Shamnad Basheer truly exemplified across his life and career. Through this scholarship, we look forward to providing new opportunities, increasing diversity, and supporting excellence across a broad range of legal careers</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "ed835553-c624-4062-b467-091a8ec84028",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "d30e5d42-e735-417d-be5f-a4904851c875",
+        "content-id": "d30e5d42-e735-417d-be5f-a4904851c875",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+      {
+        "story-elements": [
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/bafa09f9-1e1b-49bf-b8b7-2772e10e10ef",
+            type: "text",
+            "family-id": "9e54e5bc-c615-42b5-aa83-40a224fa06c5",
+            title: "",
+            id: "bafa09f9-1e1b-49bf-b8b7-2772e10e10ef",
+            metadata: {},
+            subtype: null,
+            text: "<p><strong>Looking Ahead</strong></p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/f317e92c-4b79-4c0b-9c1e-149dc07dcb12",
+            type: "text",
+            "family-id": "48da5e07-1994-4c28-bd2e-37f19f762b97",
+            title: "",
+            id: "f317e92c-4b79-4c0b-9c1e-149dc07dcb12",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>For anyone who has witnessed India’s remarkable journey to economic growth, it’s amply clear that this incredible promise needs to be supported with widespread access to world-class educational opportunities and a robust legal system. As LSAC works toward new milestones in the year ahead, it continues to be driven by the belief that access to justice forms the bedrock of every democratic society and empowers everyone. This belief remains at the heart of every partnership that LSAC forges and nurtures with law colleges in India—and the resources that they make available to aspiring law students.</p>",
+          },
+          {
+            description: "",
+            "page-url":
+              "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/85234239-45db-40d7-8c8c-187ea6149138",
+            type: "text",
+            "family-id": "a7fa4e11-abb7-4ad3-a3ab-fad1b5ebb067",
+            title: "",
+            id: "85234239-45db-40d7-8c8c-187ea6149138",
+            metadata: {},
+            subtype: null,
+            text:
+              "<p>Going forward, LSAC will continue to work closely with India’s law colleges to help ensure that their graduates can one day provide a wide array of legal services—for families, small businesses, courts, and government agencies, as well as for international corporations and law firms. Mirroring its objectives across geographies, LSAC is committed to achieving new milestones in India, opening doors for law school aspirants, and lighting the way toward opportunity and justice for all.</p>",
+          },
+        ],
+        "card-updated-at": 1581327522163,
+        "content-version-id": "49ce81ad-fe38-438f-bcd9-812384efc76b",
+        "card-added-at": 1581327522163,
+        status: "draft",
+        id: "a89cb895-d1e8-4865-b30d-5face4994722",
+        "content-id": "a89cb895-d1e8-4865-b30d-5face4994722",
+        version: 1,
+        metadata: {
+          "social-share": {
+            shareable: false,
+            title: "#Sponsored: Empowering India’s Future Lawyers and Leaders",
+            message: null,
+            image: {
+              key:
+                "barandbench/2020-02/43fb44c4-2028-4b90-95ad-dc54aad47a28/Discover_Law_Logo_1.jpg",
+              url: null,
+              attribution: "Create",
+              caption: null,
+              metadata: {
+                width: 2550,
+                height: 1162,
+                "mime-type": "image/jpeg",
+                "file-size": 185634,
+                "file-name": "Discover_Law_Logo_1.jpg",
+                "focus-point": [1275, 581],
+              },
+            },
+          },
+          attributes: {},
+        },
+      },
+    ],
+    url:
+      "https://www.barandbench.com/news/empowering-indias-future-lawyers-and-leaders",
+    "story-version-id": "1110cdc2-a1d6-4a6c-9707-f4b9b516d49e",
+    "content-type": "story",
+    "content-updated-at": 1581503851699,
+    "author-id": 708282,
+    "owner-id": 708282,
+    "linked-story-ids": ["a7a06a3f-8d9a-450c-8eaa-387b7c8c6323"],
+    access: "subscription",
+    "asana-project-id": null,
+    "first-published-at": 1581503851412,
+    "hero-image-caption": null,
+    version: 12,
+    "story-template": "text",
+    "sequence-no": null,
+    "created-at": 1581327522143,
+    authors: [
+      {
+        id: 708282,
+        name: "Ravi Kanth",
+        slug: "ravi-kanth",
+        "avatar-url":
+          "https://images.assettype.com/barandbench/2020-01/82d5c350-9791-4cdb-88d5-f52b2d98a4ab/Bar_and_Bench_Icon_Purple.png",
+        "avatar-s3-key":
+          "barandbench/2020-01/82d5c350-9791-4cdb-88d5-f52b2d98a4ab/Bar_and_Bench_Icon_Purple.png",
+        "twitter-handle": null,
+        bio: null,
+        "contributor-role": null,
+      },
+    ],
+    metadata: {
+      "sponsored-by": "Empowering India’s Future Lawyers and Leaders",
+      "card-share": {
+        shareable: false,
+      },
+    },
+    "publish-at": null,
+    "assignee-name": "Ravi Kanth",
+  };
+  Object.keys(opts).forEach((key) => {
+    if (key in story) story[key] = opts[key];
+  });
+  return story;
+};
+
+export const getTextStoryWithInvalidStoryElements = () => {
+  const accumulator = getTextStory();
+  const invalidElement = {
+    description: "",
+    "page-url":
+      "/story/d1a06f25-a8e3-44f7-9f8e-cc2fbdbb889f/element/95ffe013-4f2c-41eb-a999-877b2401cc73",
+    type: "this-is-an-unsupported-type",
+    "family-id": "4510376d-1713-4c85-9363-7995eede60cc",
+    title: "",
+    id: "95ffe013-4f2c-41eb-a999-877b2401cc73",
+    metadata: {},
+    subtype: null,
+    text:
+      "<p>இவர்களின் நோக்கம் `New World Order’ எனப்படும் புதிய உலக அமைப்பை உருவாக்குவதுதான். அந்தப் புதிய உலகில் மொத்த உலகமும் இணைந்திருக்கும். நாட்டின் எல்லைகளைக் கடந்து வணிகம் தழைக்கும். மொத்த உலகத்துக்கும் ஒற்றைத் தலைமை இருக்கும். அந்தத் தலைமை யதேச்சதிகாரத் தலைமையாக இருக்கும்.</p><p>தற்போது நடக்கும் விஷயங்களும் கிட்டத்தட்ட New World Order-ஐ நோக்கி நடப்பதுபோலவே இருக்கின்றன. ஒவ்வொரு நாட்டுக்கும் அரசு என ஒன்று இருந்தாலும், மொத்த நாட்டின் அரசுகளை இயக்குவது அமெரிக்கா என்ற ஒற்றை அரசுதான். இந்த உண்மை நம் எல்லாருக்குமே தெரியும். நாடுகளுக்கு தற்போது எல்லைகள் இருந்தாலும், பல நாட்டு நிறுவனங்கள் பிற நாடுகளுக்குள் சென்று கடைகள் விரிக்கின்றன. வணிகமும் பணமும் எல்லை பேதங்கள் இன்றி உலகமெங்கும் ஓடுகின்றன. New world order-க்கான எல்லா சாத்தியங்களையும் நெருங்குகிறோம்.</p>",
+  };
+  accumulator.cards[0]["story-elements"].push(invalidElement);
+  return accumulator;
+};

--- a/test/integration/amp-handler-test.js
+++ b/test/integration/amp-handler-test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
 /* eslint-disable func-names */
 import supertest from "supertest";
 import { ampRoutes } from "../../server/routes";
@@ -6,184 +8,193 @@ const assert = require("assert");
 const express = require("express");
 
 const ampConfig = {
-  fonts: {
-    primary: {
-      url: "Open+Sans:300,400,600,700",
-      family: '"Open Sans", sans-serif',
+  ampConfig: {
+    fonts: {
+      primary: {
+        url: "Open+Sans:300,400,600,700",
+        family: '"Open Sans", sans-serif',
+      },
+      secondary: {
+        url: "PT+Serif:400,400italic,700,700italic",
+        family: "sans-serif",
+      },
     },
-    secondary: {
-      url: "PT+Serif:400,400italic,700,700italic",
-      family: "sans-serif",
+    colors: {
+      primary: "#294f32",
+      secondary: "#763194",
+      "footer-background": "#FDBD10",
+      "section-text-color": "#f4e842",
     },
+    "invalid-elements-strategy": "redirect-to-web-version",
+    "related-collection-id": 1234,
   },
-  colors: {
-    primary: "#294f32",
-    secondary: "#763194",
-    "footer-background": "#FDBD10",
-    "section-text-color": "#f4e842",
-  },
-  "invalid-elements-strategy": "redirect-to-web-version",
-  "related-collection-id": 1234,
 };
 
-function getClientStub(hostname) {
-  return {
-    getHostname: () => "demo.quintype.io",
-    getConfig: () =>
-      Promise.resolve({
-        "cdn-name": "images.assettype.com",
-        "cdn-image": "gumlet.assettype.com",
-        "sketches-host": "https://www.vikatan.com",
-        domains: [
-          {
-            "host-url": "https://cinema.vikatan.com",
-          },
-          {
-            "host-url": "https://sports.vikatan.com",
-          },
-        ],
-        memoizeAsync: (key, fn) => {
-          return ampConfig;
+function getClientStub({
+  getHostname = () => "demo.quintype.io",
+  getConfig = () =>
+    Promise.resolve({
+      "cdn-name": "images.assettype.com",
+      "cdn-image": "gumlet.assettype.com",
+      "sketches-host": "https://www.vikatan.com",
+      domains: [
+        {
+          "host-url": "https://cinema.vikatan.com",
         },
-      }),
-    getStoryBySlug: (slug, params) =>
-      Promise.resolve({
-        story: {
-          id: "1",
-          "hero-image-metadata": {
-            width: 5472,
-            height: 3648,
-            "mime-type": "image/jpeg",
-            "file-size": 6127839,
-            "file-name": "Sample file",
-            "focus-point": [2609, 1102],
-          },
-          "hero-image-s3-key": "barandbench/2020-01/sample.jpg",
-          "story-content-id": "987c0480-41c8-41d2-ad35-36b5f92be73e",
+        {
+          "host-url": "https://sports.vikatan.com",
+        },
+      ],
+      memoizeAsync: (key, fn) => {
+        return ampConfig;
+      },
+    }),
+  getStoryBySlug = (slug, params) =>
+    Promise.resolve({
+      story: {
+        id: "1",
+        url: "https://www.foo.com/cricket/ipl-2021",
+        "hero-image-metadata": {
+          width: 5472,
+          height: 3648,
+          "mime-type": "image/jpeg",
+          "file-size": 6127839,
+          "file-name": "Sample file",
+          "focus-point": [2609, 1102],
+        },
+        "hero-image-s3-key": "barandbench/2020-01/sample.jpg",
+        "story-content-id": "987c0480-41c8-41d2-ad35-36b5f92be73e",
 
-          cards: [
-            {
-              "story-elements": [
-                {
-                  description: "",
-                  "page-url":
-                    "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
-                  type: "text",
-                  "family-id": "e9e12f9f-8b9f-4b93-a8c8-83c7b278000f",
-                  title: "",
-                  id: "9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
-                  metadata: {},
-                  subtype: null,
-                  text:
-                    "<p>In India today, the legal profession is growing in lockstep with one of the world’s most dynamic economies. It’s no surprise then— that in terms of absolute numbers— India’s legal profession is the world’s second largest, with over 1.4 million enrolled lawyers in legal practices nationwide.</p>",
-                },
-              ],
-              "card-updated-at": 1581327522163,
-              "content-version-id": "efaf78de-c90b-4d15-b040-c84ebb29cabf",
-              "card-added-at": 1581327522163,
-              status: "draft",
-              id: "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
-              "content-id": "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
-              version: 1,
-              metadata: {},
-            },
-          ],
-          sections: [{ id: 1, name: "Sports" }],
-          "story-template": "text",
-          "is-amp-supported": true,
-        },
-      }),
-    getCollectionBySlug: (slug) =>
-      Promise.resolve({
-        items: [
+        cards: [
           {
-            id: "1111",
-            type: "story",
-            story: {
-              "story-content-id": "abc",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "abc/heroimage.jpg",
-              headline: "headline1",
-              slug: "foo.com/story-a",
-            },
-          },
-          {
-            id: "2222",
-            type: "story",
-            story: {
-              "story-content-id": "def",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "def/heroimage.jpg",
-              headline: "headline2",
-              slug: "foo.com/story-a",
-            },
-          },
-          {
-            id: "3333",
-            type: "story",
-            story: {
-              "story-content-id": "ghi",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "ghi/heroimage.jpg",
-              headline: "headline3",
-              slug: "foo.com/story-c",
-            },
-          },
-          {
-            id: "4444",
-            type: "story",
-            story: {
-              "story-content-id": "jkl",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "jkl/heroimage.jpg",
-              headline: "headline4",
-              slug: "foo.com/story-d",
-            },
-          },
-          {
-            id: "5555",
-            type: "story",
-            story: {
-              "story-content-id": "mno",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "mno/heroimage.jpg",
-              headline: "headline5",
-              slug: "foo.com/story-e",
-            },
-          },
-          {
-            id: "6666",
-            type: "story",
-            story: {
-              "story-content-id": "pqr",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "pqr/heroimage.jpg",
-              headline: "headline6",
-              slug: "foo.com/story-f",
-            },
-          },
-          {
-            id: "7777",
-            type: "story",
-            story: {
-              "story-content-id": "stu",
-              "cdn-image": "gumlet.assettype.com",
-              "hero-image-s3-key": "stu/heroimage.jpg",
-              headline: "headline7",
-              slug: "foo.com/story-g",
-            },
+            "story-elements": [
+              {
+                description: "",
+                "page-url":
+                  "/story/7f3d5bdb-ec52-4047-ac0d-df4036ec974b/element/9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
+                type: "text",
+                "family-id": "e9e12f9f-8b9f-4b93-a8c8-83c7b278000f",
+                title: "",
+                id: "9eb8f5cc-6ebe-4fb0-88b8-eca79efde210",
+                metadata: {},
+                subtype: null,
+                text:
+                  "<p>In India today, the legal profession is growing in lockstep with one of the world’s most dynamic economies. It’s no surprise then— that in terms of absolute numbers— India’s legal profession is the world’s second largest, with over 1.4 million enrolled lawyers in legal practices nationwide.</p>",
+              },
+            ],
+            "card-updated-at": 1581327522163,
+            "content-version-id": "efaf78de-c90b-4d15-b040-c84ebb29cabf",
+            "card-added-at": 1581327522163,
+            status: "draft",
+            id: "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
+            "content-id": "bf486412-1e8b-45d1-a5fd-51939cfe1ce1",
+            version: 1,
+            metadata: {},
           },
         ],
-      }),
+        sections: [{ id: 1, name: "Sports" }],
+        "story-template": "text",
+        "is-amp-supported": true,
+      },
+    }),
+  getCollectionBySlug = (slug) =>
+    Promise.resolve({
+      items: [
+        {
+          id: "1111",
+          type: "story",
+          story: {
+            "story-content-id": "abc",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "abc/heroimage.jpg",
+            headline: "headline1",
+            slug: "foo.com/story-a",
+          },
+        },
+        {
+          id: "2222",
+          type: "story",
+          story: {
+            "story-content-id": "def",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "def/heroimage.jpg",
+            headline: "headline2",
+            slug: "foo.com/story-a",
+          },
+        },
+        {
+          id: "3333",
+          type: "story",
+          story: {
+            "story-content-id": "ghi",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "ghi/heroimage.jpg",
+            headline: "headline3",
+            slug: "foo.com/story-c",
+          },
+        },
+        {
+          id: "4444",
+          type: "story",
+          story: {
+            "story-content-id": "jkl",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "jkl/heroimage.jpg",
+            headline: "headline4",
+            slug: "foo.com/story-d",
+          },
+        },
+        {
+          id: "5555",
+          type: "story",
+          story: {
+            "story-content-id": "mno",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "mno/heroimage.jpg",
+            headline: "headline5",
+            slug: "foo.com/story-e",
+          },
+        },
+        {
+          id: "6666",
+          type: "story",
+          story: {
+            "story-content-id": "pqr",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "pqr/heroimage.jpg",
+            headline: "headline6",
+            slug: "foo.com/story-f",
+          },
+        },
+        {
+          id: "7777",
+          type: "story",
+          story: {
+            "story-content-id": "stu",
+            "cdn-image": "gumlet.assettype.com",
+            "hero-image-s3-key": "stu/heroimage.jpg",
+            headline: "headline7",
+            slug: "foo.com/story-g",
+          },
+        },
+      ],
+    }),
+} = {}) {
+  return {
+    getHostname,
+    getConfig,
+    getStoryBySlug,
+    getCollectionBySlug,
   };
 }
 
 const dummyAmpLib = {
   ampifyStory: () => '<div data-page-type="home-page">foobar</div>',
+  unsupportedStoryElementsPresent: () => false,
 };
 
-const getClientStubWithRelatedStories = (relatedStories) => (hostname) =>
-  Object.assign({}, getClientStub(hostname), {
+const getClientStubWithRelatedStories = (relatedStories) => () =>
+  Object.assign({}, getClientStub(), {
     getRelatedStories: () =>
       Promise.resolve({ "related-stories": relatedStories }),
   });
@@ -218,6 +229,7 @@ describe("ampStoryPageHandler integration tests", () => {
     const app = createApp({
       ampLibrary: {
         ampifyStory: () => new Error("Dummy error"),
+        unsupportedStoryElementsPresent: () => false,
       },
     });
     supertest(app)
@@ -225,6 +237,82 @@ describe("ampStoryPageHandler integration tests", () => {
       .expect(500, /Dummy error/)
       .end(function (err, res) {
         if (err) return done(err);
+        return done();
+      });
+  });
+  it("should redirect to non-amp page if story contains unsuported elements and invalid-elements-strategy in /api/v1/amp/config is set to redirect-to-web-version", (done) => {
+    const app = createApp({
+      ampLibrary: {
+        ampifyStory: () => '<div data-page-type="home-page">foobar</div>',
+        unsupportedStoryElementsPresent: () => true,
+      },
+    });
+    supertest(app)
+      .get("/amp/story/test")
+      .expect(302)
+      .expect("Location", "https://www.foo.com/cricket/ipl-2021")
+      .end((err) => {
+        if (err) return done(err);
+        return done();
+      });
+  });
+  it("should show amp page if story contains unsuported elements but invalid-elements-strategy in /api/v1/amp/config is set to any value other than redirect-to-web-version", (done) => {
+    const dummyAmpConfig = {
+      ampConfig: {
+        fonts: {
+          primary: {
+            url: "Open+Sans:300,400,600,700",
+            family: '"Open Sans", sans-serif',
+          },
+          secondary: {
+            url: "PT+Serif:400,400italic,700,700italic",
+            family: "sans-serif",
+          },
+        },
+        colors: {
+          primary: "#294f32",
+          secondary: "#763194",
+          "footer-background": "#FDBD10",
+          "section-text-color": "#f4e842",
+        },
+        "invalid-elements-strategy": "render-with-notification",
+        "related-collection-id": 1234,
+      },
+    };
+    const clientStubWithRedirectToWebVersion = () =>
+      getClientStub({
+        getConfig: () =>
+          Promise.resolve({
+            "cdn-name": "images.assettype.com",
+            "cdn-image": "gumlet.assettype.com",
+            "sketches-host": "https://www.vikatan.com",
+            domains: [
+              {
+                "host-url": "https://cinema.vikatan.com",
+              },
+              {
+                "host-url": "https://sports.vikatan.com",
+              },
+            ],
+            memoizeAsync: (key, fn) => {
+              return dummyAmpConfig;
+            },
+          }),
+      });
+    const app = createApp({
+      clientStub: clientStubWithRedirectToWebVersion,
+      ampLibrary: {
+        ampifyStory: () => '<div data-page-type="home-page">foobar</div>',
+        unsupportedStoryElementsPresent: () => true,
+      },
+    });
+    supertest(app)
+      .get("/amp/story/test")
+      .expect(200)
+      .expect("Content-Type", /html/)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.strictEqual(res.text, `<div data-page-type="home-page">foobar</div>`);
         return done();
       });
   });
@@ -241,55 +329,63 @@ describe("Amp infinite scroll handler", () => {
       .end((err) => {
         if (err) return done(err);
         return done();
-      })
+      });
   });
   it("Should return a 200 if origin is google/bing CDN", function (done) {
     const app = createApp();
     supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=55de49e4-de83-487c-93d3-82da3a3eb20b&__amp_source_origin=https://www.vikatan.com")
+      .get(
+        "/amp/api/v1/amp-infinite-scroll?story-id=55de49e4-de83-487c-93d3-82da3a3eb20b&__amp_source_origin=https://www.vikatan.com"
+      )
       .set("origin", "https://www-vikatan-com.cdn.ampproject.org")
       .expect(200)
       .expect("Content-Type", /json/)
       .end((err) => {
         if (err) return done(err);
         return done();
-      })
+      });
   });
   it("Should return a 200 if origin is subdomain", function (done) {
     const app = createApp();
     supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com")
+      .get(
+        "/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com"
+      )
       .set("origin", "https://sports.vikatan.com")
       .expect(200)
       .expect("Content-Type", /json/)
       .end((err) => {
         if (err) return done(err);
         return done();
-      })
+      });
   });
   it("Should return a 200 if origin is CDN of subdomain", function (done) {
     const app = createApp();
     supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com")
+      .get(
+        "/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com"
+      )
       .set("origin", "https://sports-vikatan-com.cdn.ampproject.org")
       .expect(200)
       .expect("Content-Type", /json/)
       .end((err) => {
         if (err) return done(err);
         return done();
-      })
+      });
   });
   it("Should return a 401 if not same origin or origin is not in whitelist", function (done) {
     const app = createApp();
     supertest(app)
-      .get("/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com")
+      .get(
+        "/amp/api/v1/amp-infinite-scroll?story-id=0743fa17-c39b-4b14-a21d-41a7ed35c4c6&__amp_source_origin=https://sports.vikatan.com"
+      )
       .set("origin", "https://www.google.com")
       .expect(401)
       .end((err, res) => {
         if (err) return done(err);
-        assert.strictEqual(res.body, "Unauthorized")
+        assert.strictEqual(res.body, "Unauthorized");
         return done();
-      })
+      });
   });
   it("returns infinite scroll json config from story 5 onwards", function (done) {
     const app = createApp();

--- a/test/unit/amp/amp-story-page-handler.js
+++ b/test/unit/amp/amp-story-page-handler.js
@@ -5,6 +5,7 @@
 const assert = require("assert");
 const cloneDeep = require("lodash/cloneDeep");
 const { ampStoryPageHandler } = require("../../../server/amp/handlers");
+const { getTextStory } = require("../../data/amp-test-data");
 
 const ampConfig = {
   "related-collection-id": "related-stories-collection",
@@ -13,11 +14,7 @@ const ampConfig = {
 function getClientStub({
   getStoryBySlug = (slug, params) =>
     Promise.resolve({
-      story: {
-        "is-amp-supported": true,
-        "story-content-id": 111,
-        heading: "Dogecoin surges to $10 billion",
-      },
+      story: getTextStory({ "story-content-id": 111 }),
     }),
   getCollectionBySlug = (slug) => {
     switch (slug) {
@@ -135,7 +132,6 @@ describe("ampStoryPageHandler unit tests", function () {
         {
           type: "story",
           id: 111,
-          heading: "Dogecoin surges to $10 billion",
           story: "Dogecoin surges to $10 billion",
         },
         {
@@ -236,29 +232,40 @@ describe("ampStoryPageHandler unit tests", function () {
     assert.strictEqual(isCorrectPageType, true);
     assert.strictEqual(seoPassedToAmpLib, "this is the seo string");
   });
-  // this is failing
   it("should call getAdditionalConfig method if it's passed from FE; pass it on to amplib as additionalConfig", async function () {
     let getAdditionalConfigCalled = false;
+    let additionalConfigReceivedByAmplib;
     async function dummyGetAdditionalConfig(params) {
       return new Promise((resolve) => {
         setTimeout(() => {
           getAdditionalConfigCalled = true;
-          resolve({ some: "value" });
+          resolve({ key222: "this is the fetched additional config" });
         }, 15);
       });
     }
     const dummyOpts = {
       getAdditionalConfig: dummyGetAdditionalConfig,
     };
+    const dummyAmpLib = {
+      ampifyStory: (params) => {
+        additionalConfigReceivedByAmplib = JSON.stringify(params.additionalConfig)
+      },
+      unsupportedStoryElementsPresent: () => false,
+    };
     await ampStoryPageHandler(dummyReq, dummyRes, dummyNext, {
       client: getClientStub(),
       config: dummyConfig,
       domainSlug: null,
       seo: "",
-      additionalConfig: { sideNote: "this contains bk config by default" },
+      additionalConfig: { key111: "this contains bk config by default" },
+      ampLibrary: dummyAmpLib,
       InfiniteScrollAmp: DummyInfiniteScrollAmp,
       ...dummyOpts,
     });
     assert.strictEqual(getAdditionalConfigCalled, true);
+    assert.strictEqual(additionalConfigReceivedByAmplib, JSON.stringify({
+      key111: 'this contains bk config by default',
+      key222: 'this is the fetched additional config'
+    }))
   });
 });

--- a/test/unit/amp/amp-story-page-handler.js
+++ b/test/unit/amp/amp-story-page-handler.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
 /* eslint-disable func-names */
 
 const assert = require("assert");
@@ -120,6 +122,7 @@ describe("ampStoryPageHandler unit tests", function () {
         const relStories = params.opts.featureConfig.relatedStories.stories;
         if (relStories.length) relatedStories = JSON.stringify(relStories);
       },
+      unsupportedStoryElementsPresent: () => false,
     };
     const dummyConfig2 = {
       memoizeAsync: (key, fn) =>
@@ -183,6 +186,7 @@ describe("ampStoryPageHandler unit tests", function () {
         const relStories = params.opts.featureConfig.relatedStories.stories;
         if (relStories.length) relatedStories = JSON.stringify(relStories);
       },
+      unsupportedStoryElementsPresent: () => false,
     };
     const dummyConfig2 = {
       memoizeAsync: (key, fn) =>
@@ -218,6 +222,7 @@ describe("ampStoryPageHandler unit tests", function () {
       ampifyStory: (params) => {
         seoPassedToAmpLib = params.seo;
       },
+      unsupportedStoryElementsPresent: () => false,
     };
     await ampStoryPageHandler(dummyReq, dummyRes, dummyNext, {
       client: getClientStub(),
@@ -231,6 +236,7 @@ describe("ampStoryPageHandler unit tests", function () {
     assert.strictEqual(isCorrectPageType, true);
     assert.strictEqual(seoPassedToAmpLib, "this is the seo string");
   });
+  // this is failing
   it("should call getAdditionalConfig method if it's passed from FE; pass it on to amplib as additionalConfig", async function () {
     let getAdditionalConfigCalled = false;
     async function dummyGetAdditionalConfig(params) {


### PR DESCRIPTION
# Description

Platform sends a field `is-amp-supported` in the story API. If `is-amp-supported` was false, we were showing a banner telling the reader that the story is not AMP supported.
Relying on platform's `is-amp-supported` didn't make sense anymore since AMP pages are now handled by amplib. So we moved this logic to ampLib.
Added a helper function called `unsupportedStoryElementsPresent` in amplib for this purpose.

# Fixes 
https://github.com/quintype/ace-planning/issues/336

# Dependencies 
https://github.com/quintype/quintype-amp/pull/337

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added following integration tests for ampStoryPageHandler:
- should redirect to non-amp page if story contains unsuported elements and invalid-elements-strategy in /api/v1/amp/config is set to redirect-to-web-version
- should show amp page if story contains unsuported elements but invalid-elements-strategy in /api/v1/amp/config is set to any value other than redirect-to-web-version

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules