### PR TITLE
adds ability to include cache tags based on its rules for an automated collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.3",
+  "version": "4.13.8-collection-cache.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2233,9 +2233,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "1.24.3-collection-cache.4",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.24.3-collection-cache.4.tgz",
-      "integrity": "sha512-Ff40tL5j4HCzGqJbPAEsXUb5I48qBaz6fBXVCbTPAc3mQLnPHWBAW/M0DQYzmjrpvIfDVpv6mH+MCR318tBUDg==",
+      "version": "1.25.0-collection-cache.2",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.25.0-collection-cache.2.tgz",
+      "integrity": "sha512-4XM8v3xrdIKywmyvnDciqr/beBh3FgNj4KuNOotuRiQeVCaz9AhEwXA8dax8rIE2EVQi8vnPgb0bVib40Nw8vg==",
       "requires": {
         "lodash": "^4.17.15",
         "object-hash": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,9 +2233,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "1.25.0-collection-cache.2",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.25.0-collection-cache.2.tgz",
-      "integrity": "sha512-4XM8v3xrdIKywmyvnDciqr/beBh3FgNj4KuNOotuRiQeVCaz9AhEwXA8dax8rIE2EVQi8vnPgb0bVib40Nw8vg==",
+      "version": "1.25.0-collection-cache.4",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.25.0-collection-cache.4.tgz",
+      "integrity": "sha512-/PSE+59dgrxkr/DMV+LAR7f3UgnqTV72O663QLQxYor9E7QOPgUDN33s58dOAdKdlGqOiTZG+QPTsDkV+5L6Pg==",
       "requires": {
         "lodash": "^4.17.15",
         "object-hash": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.4",
+  "version": "4.13.8-collection-cache.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.5",
+  "version": "4.13.8-collection-cache.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,9 +2233,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "1.25.0-collection-cache.4",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.25.0-collection-cache.4.tgz",
-      "integrity": "sha512-/PSE+59dgrxkr/DMV+LAR7f3UgnqTV72O663QLQxYor9E7QOPgUDN33s58dOAdKdlGqOiTZG+QPTsDkV+5L6Pg==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.25.1.tgz",
+      "integrity": "sha512-eP+4XM1WzEBXVgJeZq6jjannArCzgDUCBAMhj6kZOOnwEY6VAI4Fj7woME+Sh5K8v6FdVaUCn1KdN8tjHhZP/Q==",
       "requires": {
         "lodash": "^4.17.15",
         "object-hash": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.1",
+  "version": "4.13.8-collection-cache.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.7",
+  "version": "4.13.8-collection-cache.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2233,9 +2233,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.24.2.tgz",
-      "integrity": "sha512-EZB/yT63+B07focrUimoyqm25FxHK0alT+Fw5tMs0JylXRsTD3SgiJGPYMCbr8Kk1ms4uY2Ks7U294mp6rrvMQ==",
+      "version": "1.24.3-collection-cache.4",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-1.24.3-collection-cache.4.tgz",
+      "integrity": "sha512-Ff40tL5j4HCzGqJbPAEsXUb5I48qBaz6fBXVCbTPAc3mQLnPHWBAW/M0DQYzmjrpvIfDVpv6mH+MCR318tBUDg==",
       "requires": {
         "lodash": "^4.17.15",
         "object-hash": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.2",
+  "version": "4.13.8-collection-cache.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.1",
+  "version": "4.13.8-collection-cache.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.4",
+  "version": "4.13.8-collection-cache.5",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
     "@quintype/amp": "^2.4.1",
-    "@quintype/backend": "^1.24.2",
+    "@quintype/backend": "1.24.3-collection-cache.4",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",
     "@quintype/seo": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.5",
+  "version": "4.13.8-collection-cache.6",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2",
+  "version": "4.13.2-collection-cache.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.3",
+  "version": "4.13.8-collection-cache.4",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
     "@quintype/amp": "^2.4.1",
-    "@quintype/backend": "1.24.3-collection-cache.4",
+    "@quintype/backend": "1.25.0-collection-cache.2",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",
     "@quintype/seo": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
     "@quintype/amp": "^2.4.1",
-    "@quintype/backend": "1.25.0-collection-cache.4",
+    "@quintype/backend": "1.25.1",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",
     "@quintype/seo": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.8-collection-cache.2",
+  "version": "4.13.8-collection-cache.3",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.13.2-collection-cache.1",
+  "version": "4.13.8-collection-cache.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
     "@quintype/amp": "^2.4.1",
-    "@quintype/backend": "1.25.0-collection-cache.2",
+    "@quintype/backend": "1.25.0-collection-cache.4",
     "@quintype/components": "^2.16.1",
     "@quintype/prerender-node": "^3.2.24",
     "@quintype/seo": "^1.38.1",

--- a/server/impl/api-client-impl.js
+++ b/server/impl/api-client-impl.js
@@ -92,11 +92,11 @@ Collection.prototype.isAutomated = function() {
 };
 
 Collection.prototype.getChildCollections = function() {
-  return this.items && this.items.filter((i) => i.type === 'collection');
+  return this.items && this.items.filter((i) => i.type === "collection");
 };
 
 Collection.prototype.getChildStories = function() {
-  return this.items && this.items.filter((i) => i.type !== 'collection');
+  return this.items && this.items.filter((i) => i.type === "story");
 };
 
 Collection.prototype.getCacheableChildItems = function(depth) {

--- a/server/impl/api-client-impl.js
+++ b/server/impl/api-client-impl.js
@@ -95,16 +95,16 @@ Collection.prototype.getChildCollections = function() {
   return this.items && this.items.filter((i) => i.type === "collection");
 };
 
-Collection.prototype.getChildStories = function() {
-  return this.items && this.items.filter((i) => i.type === "story");
-};
-
 Collection.prototype.getCacheableChildItems = function() {
   return this.isAutomated() ? this.getChildCollections() : this.items;
 };
 
+Collection.prototype.isLeafCollection = function() {
+  return !this.getCacheableChildItems() && !this["collection-cache-keys"];
+};
+
 Collection.prototype.cacheKeys = function (publisherId, depth) {
-  if (depth < 0) {
+  if (depth < 0 || this.isLeafCollection()) {
     return [collectionToCacheKey(publisherId,this)];
   }
   const remainingDepth = _.isNumber(depth) ? (depth - 1) : depth;

--- a/server/impl/api-client-impl.js
+++ b/server/impl/api-client-impl.js
@@ -38,12 +38,12 @@ function createTemporaryClient(config, hostname) {
     return new Client(`https://${hostname.replace(matchedString, "")}`, true);
 }
 
-function itemToCacheKey(publisherId, item) {
+function itemToCacheKey(publisherId, item, depth) {
   switch (item.type) {
     case "story":
       return [storyToCacheKey(publisherId, item.story)];
     case "collection":
-      return Collection.build(item).cacheKeys(publisherId).slice(0, 5);
+      return Collection.build(item).cacheKeys(publisherId, depth);
     default:
       return [];
   }
@@ -70,6 +70,7 @@ function getItemCacheKeys(publisherId, items, depth) {
   return { storyCacheKeys, collectionCacheKeys };
 }
 
+// TODO: Can getCollectionCacheKeys be removed?
 Collection.prototype.getCollectionCacheKeys = function (publisherId, depth) {
   if (!depth) {
     return {
@@ -86,22 +87,30 @@ Collection.prototype.getCollectionCacheKeys = function (publisherId, depth) {
   return { storyCacheKeys, collectionCacheKeys };
 };
 
+Collection.prototype.isAutomated = function() {
+  return !!this.automated;
+};
+
+Collection.prototype.getChildCollections = function() {
+  return this.items && this.items.filter((i) => i.type === 'collection');
+};
+
+Collection.prototype.getChildStories = function() {
+  return this.items && this.items.filter((i) => i.type !== 'collection');
+};
+
 Collection.prototype.cacheKeys = function (publisherId, depth) {
-  if (!depth) {
-    return [collectionToCacheKey(publisherId, this)].concat([
-      ..._.flatMap(this.items, (item) => itemToCacheKey(publisherId, item)),
-      ...(this["collection-cache-keys"] ? this["collection-cache-keys"] : []),
-    ]);
+  let cacheableChildItems;
+  if (depth <= 0) {
+    cacheableChildItems = this.isAutomated() ? [] : this.getChildStories();
+  } else {
+    cacheableChildItems = this.isAutomated() ? this.getChildCollections() : this.items;
   }
-  const { storyCacheKeys, collectionCacheKeys } = getItemCacheKeys(
-    publisherId,
-    this.items,
-    depth + 1
-  );
-  return [collectionToCacheKey(publisherId, this)].concat([
-    ...collectionCacheKeys,
-    ...storyCacheKeys.slice(0, 200 - collectionCacheKeys.length),
+
+  const remainingDepth = _.isNumber(depth) ? (depth - 1) : depth;
+  return ([
     ...(this["collection-cache-keys"] ? this["collection-cache-keys"] : []),
+    ..._.flatMap(cacheableChildItems, (item) => itemToCacheKey(publisherId, item, remainingDepth)),
   ]);
 };
 

--- a/server/impl/api-client-impl.js
+++ b/server/impl/api-client-impl.js
@@ -99,18 +99,21 @@ Collection.prototype.getChildStories = function() {
   return this.items && this.items.filter((i) => i.type !== 'collection');
 };
 
-Collection.prototype.cacheKeys = function (publisherId, depth) {
+Collection.prototype.getCacheableChildItems = function(depth) {
   let cacheableChildItems;
   if (depth <= 0) {
     cacheableChildItems = this.isAutomated() ? [] : this.getChildStories();
   } else {
     cacheableChildItems = this.isAutomated() ? this.getChildCollections() : this.items;
   }
+  return cacheableChildItems;
+};
 
+Collection.prototype.cacheKeys = function (publisherId, depth) {
   const remainingDepth = _.isNumber(depth) ? (depth - 1) : depth;
   return ([
     ...(this["collection-cache-keys"] ? this["collection-cache-keys"] : []),
-    ..._.flatMap(cacheableChildItems, (item) => itemToCacheKey(publisherId, item, remainingDepth)),
+    ..._.flatMap(this.getCacheableChildItems(depth), (item) => itemToCacheKey(publisherId, item, remainingDepth)),
   ]);
 };
 

--- a/server/impl/api-client-impl.js
+++ b/server/impl/api-client-impl.js
@@ -99,21 +99,18 @@ Collection.prototype.getChildStories = function() {
   return this.items && this.items.filter((i) => i.type === "story");
 };
 
-Collection.prototype.getCacheableChildItems = function(depth) {
-  let cacheableChildItems;
-  if (depth <= 0) {
-    cacheableChildItems = this.isAutomated() ? [] : this.getChildStories();
-  } else {
-    cacheableChildItems = this.isAutomated() ? this.getChildCollections() : this.items;
-  }
-  return cacheableChildItems;
+Collection.prototype.getCacheableChildItems = function() {
+  return this.isAutomated() ? this.getChildCollections() : this.items;
 };
 
 Collection.prototype.cacheKeys = function (publisherId, depth) {
+  if (depth < 0) {
+    return [collectionToCacheKey(publisherId,this)];
+  }
   const remainingDepth = _.isNumber(depth) ? (depth - 1) : depth;
   return ([
     ...(this["collection-cache-keys"] ? this["collection-cache-keys"] : []),
-    ..._.flatMap(this.getCacheableChildItems(depth), (item) => itemToCacheKey(publisherId, item, remainingDepth)),
+    ..._.flatMap(this.getCacheableChildItems(), (item) => itemToCacheKey(publisherId, item, remainingDepth)),
   ]);
 };
 

--- a/test/unit/api-client-test.js
+++ b/test/unit/api-client-test.js
@@ -174,6 +174,73 @@ describe("ApiClient", function () {
 
       assert.doesNotThrow(() => collection.getChildCollections());
     });
+
+    it("should return empty array as cacheable child items when depth is less than or equal to zero for an automated collection", () => {
+      const collection = Collection.build({
+        id: "42",
+        automated: true,
+        "collection-cache-keys": ["c/1/42", "sc/1/1233"],
+        items: [{ type: "story", story: { id: "xyz1235" } }],
+      });
+
+      assert.strictEqual(collection.getCacheableChildItems(0).length, 0);
+      assert.strictEqual(collection.getCacheableChildItems(-1).length, 0);
+    });
+
+    it("should return all child collections as cacheable child items when depth is undefined or greater than zero for an automated collection", () => {
+      const collection = Collection.build({
+        id: "42",
+        automated: true,
+        "collection-cache-keys": ["c/1/42", "sc/1/1233"],
+        items: [
+          { type: "story", story: { id: "xyz1235" } },
+          {
+            type: "collection",
+            "collection-cache-keys": ["c/1/851", "sc/1/114"],
+            automated: true,
+            id: "851",
+            items: [{ type: "story", story: { id: "xyz1235" } }],
+          },
+        ],
+      });
+
+      assert.strictEqual(collection.getCacheableChildItems(1).filter((c) => c.type === 'collection').length, 1);
+      assert.strictEqual(collection.getCacheableChildItems(1)[0].id, "851");
+
+      assert.strictEqual(collection.getCacheableChildItems().filter((c) => c.type === 'collection').length, 1);
+      assert.strictEqual(collection.getCacheableChildItems()[0].id, "851");
+    });
+
+    it("should return only stories as cacheable child items when depth is less than or equal to zero for manual collection", () => {
+      const collection = Collection.build({
+        id: "42",
+        automated: false,
+        "collection-cache-keys": ["c/1/42", "sc/1/1233"],
+        items: [{ type: "story", story: { id: "xyz1235" } }],
+      });
+
+      assert.notStrictEqual(collection.getCacheableChildItems(0), ["s/1/xyz1235"]);
+    });
+
+    it("should return all child items as cacheable child items when depth is undefined or greater than zero for an automated collection", () => {
+      const collection = Collection.build({
+        id: "42",
+        "collection-cache-keys": ["c/1/42", "sc/1/1233"],
+        items: [
+          { type: "story", story: { id: "xyz1235" } },
+          {
+            type: "collection",
+            "collection-cache-keys": ["c/1/851", "sc/1/114"],
+            automated: true,
+            id: "851",
+            items: [{ type: "story", story: { id: "xyz1235" } }],
+          },
+        ],
+      });
+
+      assert.strictEqual(collection.getCacheableChildItems(1).length, 2);
+      assert.strictEqual(collection.getCacheableChildItems().length, 2);
+    });
   });
 
   describe("caching", function () {

--- a/test/unit/api-client-test.js
+++ b/test/unit/api-client-test.js
@@ -489,6 +489,7 @@ describe("ApiClient", function () {
                 items: [
                   {
                     type: "collection",
+                    "collection-cache-keys": ["c/1/900"],
                     id: "900",
                     items: [
                       { type: "story", story: { id: "xyz12" } },
@@ -517,14 +518,17 @@ describe("ApiClient", function () {
             "sc/1/38588",
             "c/1/700",
             "s/1/abcdef12",
+            "c/1/850",
             "c/1/800",
+            "c/1/900",
             "s/1/xyz12",
+            "c/1/851"
           ],
         collection.cacheKeys(1, 3)
       );
     });
 
-    it("should only include base collection cache keys for an automated collection when depth is given as zero", function () {
+    it("should only include base collection cache keys and child items id as tags for an automated collection when depth is zero", function () {
       const collection = Collection.build({
         id: "42",
         "collection-cache-keys": ["c/1/42", "sc/1/38586"],
@@ -587,10 +591,10 @@ describe("ApiClient", function () {
         ],
       });
 
-      assert.deepEqual(["c/1/42", "sc/1/38586"], collection.cacheKeys(1, 0));
+      assert.deepEqual(["c/1/42", "sc/1/38586", "c/1/500"], collection.cacheKeys(1, 0));
     });
 
-    it("should only include base collection cache keys and base stories for manual collection when depth is given as zero", function () {
+    it("should only include base collection cache keys, item ids at level zero for manual collection when depth is zero", function () {
       const collection = Collection.build({
         id: "42",
         "collection-cache-keys": ["c/1/42"],
@@ -622,7 +626,7 @@ describe("ApiClient", function () {
         ],
       });
 
-      assert.deepEqual(["c/1/42", "s/1/abcdef12"], collection.cacheKeys(1, 0));
+      assert.deepEqual(["c/1/42", "c/1/500", "s/1/abcdef12"], collection.cacheKeys(1, 0));
     });
 
     it("should add all nested collection cache tags when depth is not passed", function () {


### PR DESCRIPTION
# Description

First 4 Story tags were used as cache tags for an automated collection. However an automated collection can have N number of stories and collections under it and new items can be added at any time. So using story tags as cache tags is not extensible and error prone.

To fix this, instead of stories we are including the rules that make up the automated collection. And whenever a story matching a rule gets published it's corresponding rule tag also gets purged. That way all the automated collections that depend on this rule tag gets invalidated.

Fixes # (issue-reference)

https://github.com/quintype/itsman/issues/7411

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
