### PR TITLE
fix: bump amplib to take invalidBanner fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,15 +2215,16 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.1.tgz",
-      "integrity": "sha512-UrHIKbGZW3jG9wE+DaDg+FcKPBdSqtRriWSVYR15dtG0ShKLytYBJAQ1pPO+H5gHmJyMaA+RFyBCyEDZycRcgw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.2.tgz",
+      "integrity": "sha512-p45QSsmDDY6/Ll0qQaxV8V+Q+KXHoD2XPFktJlh1s9+QGr/8qnaPPaPfZxfDKcRg3pTXEgZ+feVL92NQF0Fk/Q==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",
         "date-fns": "^2.11.0",
         "date-fns-tz": "^1.0.10",
         "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "node-html-parser": "^1.2.20",
@@ -12823,6 +12824,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -14950,9 +14956,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "performant-array-to-tree": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.8.1.tgz",
-      "integrity": "sha512-Lh3NddecUKVZ7Eims6Im5gyo2IXTFAxcHc14gHXhzP13VD17Seka1hASrwnMGz4Hr2hs+Ww6K5B2BF/627vNoQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.9.0.tgz",
+      "integrity": "sha512-GUFwL74i1B9uSFr9wwttwHEv2Upqu4yv6QniFE/JbezZ9t6BESzrmShiOCJhHE55TxBa1qgfNNkn/puVil9Wuw=="
     },
     "picomatch": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "^2.6.0",
-    "@quintype/amp": "^2.4.1",
+    "@quintype/amp": "^2.4.2",
     "@quintype/backend": "1.25.1",
     "@quintype/components": "^2.29.2",
     "@quintype/prerender-node": "^3.2.24",


### PR DESCRIPTION
one of the reasons for https://github.com/quintype/ace-planning/issues/415