### PR TITLE
Add defensive check for amp related collection

### DIFF
--- a/server/amp/handlers/story-page.js
+++ b/server/amp/handlers/story-page.js
@@ -52,7 +52,8 @@ async function ampStoryPageHandler(
       relatedStoriesCollection = await client.getCollectionBySlug(ampConfig["related-collection-id"]);
     if (relatedStoriesCollection) {
       const storiesToTake = get(domainSpecificOpts, ["featureConfig", "relatedStories", "storiesToTake"], 5);
-      relatedStories = relatedStoriesCollection.items
+      relatedStories = relatedStoriesCollection.items &&
+        relatedStoriesCollection.items
         .filter((item) => item.type === "story" && item.id !== story["story-content-id"])
         .slice(0, storiesToTake)
         .map((item) => item.story);


### PR DESCRIPTION
Issue happening for https://www.quintype.com/blog/ampstories/business/digital-news-report-2019-a-visual-story
Update: Turns out this is not the necessary fix. Closing.