### PR TITLE
fix(TTL) :  Support overriding of response cache header s-maxage  from  Sketches Proxy ⚡ 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.5-ttl-part2.0",
+  "version": "5.0.5-ttl-part2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.3",
+  "version": "4.16.16-ttl-part2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.6",
+  "version": "5.0.4-ttl-part2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.5",
+  "version": "5.0.4-ttl-part2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.0",
+  "version": "4.16.16-ttl-part2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.4",
+  "version": "5.0.4-ttl-part2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.15",
+  "version": "4.16.16-ttl-part2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.2",
+  "version": "4.16.16-ttl-part2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4",
+  "version": "5.0.5-ttl-part2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.3",
+  "version": "5.0.4-ttl-part2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.0",
+  "version": "5.0.4-ttl-part2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.3",
+  "version": "5.0.4-ttl-part2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.1",
+  "version": "4.16.16-ttl-part2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.2",
+  "version": "5.0.4-ttl-part2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.1",
+  "version": "5.0.4-ttl-part2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.5-ttl-part2.1",
+  "version": "5.0.5-ttl-part2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.4",
+  "version": "5.0.4-ttl-part2.5",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.5",
+  "version": "5.0.4-ttl-part2.6",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.2",
+  "version": "4.16.16-ttl-part2.3",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.5-ttl-part2.1",
+  "version": "5.0.5-ttl-part2.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.5-ttl-part2.0",
+  "version": "5.0.5-ttl-part2.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.1",
+  "version": "4.16.16-ttl-part2.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4",
+  "version": "5.0.5-ttl-part2.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.6",
+  "version": "5.0.4-ttl-part2.7",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.3",
+  "version": "5.0.4-ttl-part2.4",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.1",
+  "version": "5.0.4-ttl-part2.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.0",
+  "version": "4.16.16-ttl-part2.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.3",
+  "version": "5.0.4-ttl-part2.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.16-ttl-part2.3",
+  "version": "4.16.16-ttl-part2.4",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.0",
+  "version": "5.0.4-ttl-part2.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "4.16.15",
+  "version": "4.16.16-ttl-part2.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "5.0.4-ttl-part2.2",
+  "version": "5.0.4-ttl-part2.3",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -18,15 +18,10 @@ const {
 
 const { oneSignalImport } = require("./handlers/one-signal");
 const { customRouteHandler } = require("./handlers/custom-route-handler");
-const {
-  handleManifest,
-  handleAssetLink,
-} = require("./handlers/json-manifest-handlers");
+const { handleManifest, handleAssetLink } = require("./handlers/json-manifest-handlers");
 const { redirectStory } = require("./handlers/story-redirect");
 const { simpleJsonHandler } = require("./handlers/simple-json-handler");
-const {
-  makePickComponentSync,
-} = require("../isomorphic/impl/make-pick-component-sync");
+const { makePickComponentSync } = require("../isomorphic/impl/make-pick-component-sync");
 const { registerFCMTopic } = require("./handlers/fcm-registration-handler");
 const rp = require("request-promise");
 const bodyParser = require("body-parser");
@@ -60,13 +55,12 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
   const host = config.sketches_host;
   const apiProxy = require("http-proxy").createProxyServer({
     target: host,
-    ssl: host.startsWith("https")
-      ? { servername: host.replace(/^https:\/\//, "") }
-      : undefined,
+    ssl: host.startsWith("https") ? { servername: host.replace(/^https:\/\//, "") } : undefined,
   });
 
   apiProxy.on("proxyReq", (proxyReq, req, res, options) => {
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
+    
   });
 
   const sketchesProxy = (req, res) => apiProxy.web(req, res);
@@ -75,9 +69,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     getClient(req.hostname)
       .getConfig()
       .then(() => res.send("pong"))
-      .catch(() =>
-        res.status(503).send({ error: { message: "Config not loaded" } })
-      );
+      .catch(() => res.status(503).send({ error: { message: "Config not loaded" } }));
   });
 
   app.all("/api/*", sketchesProxy);
@@ -188,9 +180,7 @@ function wrapLoadDataWithMultiDomain(publisherConfig, f, configPos) {
     const { domainSlug } = arguments[arguments.length - 1];
     const config = arguments[configPos];
     const primaryHostUrl = convertToDomain(config["sketches-host"]);
-    const domain = (config.domains || []).find(
-      (d) => d.slug === domainSlug
-    ) || {
+    const domain = (config.domains || []).find((d) => d.slug === domainSlug) || {
       "host-url": primaryHostUrl,
     };
     const result = await f.apply(this, arguments);
@@ -296,8 +286,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
     lightPages = false,
     cdnProvider = "cloudflare",
     serviceWorkerPaths = ["/service-worker.js"],
-    maxConfigVersion = (config) =>
-      get(config, ["theme-attributes", "cache-burst"], 0),
+    maxConfigVersion = (config) => get(config, ["theme-attributes", "cache-burst"], 0),
     configWrapper = (config) => config,
 
     // The below are primarily for testing
@@ -313,31 +302,18 @@ exports.isomorphicRoutes = function isomorphicRoutes(
     sMaxAge = "900",
   }
 ) {
-  const withConfig = withConfigPartial(
-    getClient,
-    logError,
-    publisherConfig,
-    configWrapper
-  );
+  const withConfig = withConfigPartial(getClient, logError, publisherConfig, configWrapper);
 
   pickComponent = makePickComponentSync(pickComponent);
   loadData = wrapLoadDataWithMultiDomain(publisherConfig, loadData, 2);
-  loadErrorData = wrapLoadDataWithMultiDomain(
-    publisherConfig,
-    loadErrorData,
-    1
-  );
+  loadErrorData = wrapLoadDataWithMultiDomain(publisherConfig, loadErrorData, 1);
 
   if (prerenderServiceUrl) {
     app.use((req, res, next) => {
       if (req.query.prerender) {
         try {
           // eslint-disable-next-line global-require
-          prerender.set("prerenderServiceUrl", prerenderServiceUrl)(
-            req,
-            res,
-            next
-          );
+          prerender.set("prerenderServiceUrl", prerenderServiceUrl)(req, res, next);
         } catch (e) {
           logError(e);
         }
@@ -411,17 +387,10 @@ exports.isomorphicRoutes = function isomorphicRoutes(
     })
   );
 
-  app.post(
-    "/register-fcm-topic",
-    bodyParser.json(),
-    withConfig(registerFCMTopic, { publisherConfig })
-  );
+  app.post("/register-fcm-topic", bodyParser.json(), withConfig(registerFCMTopic, { publisherConfig }));
 
   if (manifestFn) {
-    app.get(
-      "/manifest.json",
-      withConfig(handleManifest, { manifestFn, logError })
-    );
+    app.get("/manifest.json", withConfig(handleManifest, { manifestFn, logError }));
   }
 
   if (mobileApiEnabled) {
@@ -445,10 +414,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
   }
 
   if (assetLinkFn) {
-    app.get(
-      "/.well-known/assetlinks.json",
-      withConfig(handleAssetLink, { assetLinkFn, logError })
-    );
+    app.get("/.well-known/assetlinks.json", withConfig(handleAssetLink, { assetLinkFn, logError }));
   }
 
   if (templateOptions) {
@@ -508,10 +474,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
   );
 
   if (redirectRootLevelStories) {
-    app.get(
-      "/:storySlug",
-      withConfig(redirectStory, { logError, cdnProvider, sMaxAge })
-    );
+    app.get("/:storySlug", withConfig(redirectStory, { logError, cdnProvider, sMaxAge }));
   }
 
   if (handleCustomRoute) {
@@ -562,9 +525,7 @@ exports.getWithConfig = getWithConfig;
  * @param opts.cacheControl The cache control header to set on proxied requests (default: *"public,max-age=15,s-maxage=240,stale-while-revalidate=300,stale-if-error=3600"*)
  */
 exports.proxyGetRequest = function (app, route, handler, opts = {}) {
-  const {
-    cacheControl = "public,max-age=15,s-maxage=240,stale-while-revalidate=300,stale-if-error=3600",
-  } = opts;
+  const { cacheControl = "public,max-age=15,s-maxage=240,stale-while-revalidate=300,stale-if-error=3600" } = opts;
 
   getWithConfig(app, route, proxyHandler, opts);
 
@@ -597,16 +558,13 @@ exports.proxyGetRequest = function (app, route, handler, opts = {}) {
 // This could also be done using express's mount point, but /ping stops working
 exports.mountQuintypeAt = function (app, mountAt) {
   app.use(function (req, res, next) {
-    const mountPoint =
-      typeof mountAt === "function" ? mountAt(req.hostname) : mountAt;
+    const mountPoint = typeof mountAt === "function" ? mountAt(req.hostname) : mountAt;
 
     if (mountPoint && req.url.startsWith(mountPoint)) {
       req.url = req.url.slice(mountPoint.length) || "/";
       next();
     } else if (mountPoint && req.url !== "/ping") {
-      res
-        .status(404)
-        .send(`Not Found: Quintype has been mounted at ${mountPoint}`);
+      res.status(404).send(`Not Found: Quintype has been mounted at ${mountPoint}`);
     } else {
       next();
     }
@@ -629,19 +587,10 @@ exports.mountQuintypeAt = function (app, mountAt) {
  *
  */
 exports.ampRoutes = (app, opts = {}) => {
-  const {
-    ampStoryPageHandler,
-    storyPageInfiniteScrollHandler,
-    bookendHandler,
-  } = require("./amp/handlers");
+  const { ampStoryPageHandler, storyPageInfiniteScrollHandler, bookendHandler } = require("./amp/handlers");
 
   getWithConfig(app, "/amp/story/*", ampStoryPageHandler, opts);
-  getWithConfig(
-    app,
-    "/amp/api/v1/amp-infinite-scroll",
-    storyPageInfiniteScrollHandler,
-    opts
-  );
+  getWithConfig(app, "/amp/api/v1/amp-infinite-scroll", storyPageInfiniteScrollHandler, opts);
   getWithConfig(app, "/amp/api/v1/bookend.json", bookendHandler, opts);
   getWithConfig(app, "/ampstories/*", ampStoryPageHandler, opts);
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -37,7 +37,7 @@ const prerender = require("@quintype/prerender-node");
  * @param {Object} opts Options
  * @param {Array<string>} opts.extraRoutes Additionally forward some routes upstream. This takes an array of express compatible routes, such as ["/foo/*"]
  * @param {boolean} opts.forwardAmp Forward amp story routes upstream (default false)
- * @param {number} opts.sMaxAge Support overriding of proxied response cache header `s-maxage` from Sketches. For Breaking News and if the cacheability is Private, it is not overwritten instead the cache control will be the same as how it's set in sketches
+ * @param {number} opts.sMaxAge Support overriding of proxied response cache header `s-maxage` from Sketches. For Breaking News and if the cacheability is Private, it is not overwritten instead the cache control will be the same as how it's set in sketches. We can set `isomorphicRoutesSmaxage: 9000` under `publisher` in publisher.yml config file that comes from BlackKnight or pass sMaxAge as a param.
  * @param {boolean} opts.forwardFavicon Forward favicon requests to the CMS (default false)
  * @param {boolean} opts.isSitemapUrlEnabled To enable /news_sitemap/today and /news_sitemap/yesterday sitemap news url (default /news_sitemap.xml)
  */
@@ -64,6 +64,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
   apiProxy.on("proxyReq", (proxyReq, req, res, options) => {
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
   });
+
+  sMaxAge = get(config, ["publisher", "upstreamRoutesSmaxage"], sMaxAge);
 
   parseInt(sMaxAge) &&
     apiProxy.on("proxyRes", function (proxyRes, req) {
@@ -273,7 +275,7 @@ function getWithConfig(app, route, handler, opts = {}) {
  * @param {Array<object>|function} opts.redirectUrls An array or async function which used to render the redirect url provided in the array of object - >ex- REDIRECT_URLS = [{sourceUrl: "/tag/:tagSlug",destinationUrl: "/topic/:tagSlug",statusCode: 301,}]
  * @param {boolean|function} redirectToLowercaseSlugs If set or evaluates to true, then for every story-page request having capital latin letters in the slug, it responds with a 301 redirect to the lowercase slug URL. (default: true)
  * @param {boolean|function} shouldEncodeAmpUri If set to true, then for every story-page request the slug will be encoded, in case of a vernacular slug this should be set to false. Receives path as param (default: true)
- * @param {string} sMaxAge Overrides the s-maxage value, the default value is set to 900 seconds
+ * @param {number} sMaxAge Overrides the s-maxage value, the default value is set to 900 seconds. We can set `isomorphicRoutesSmaxage: 9000` under `publisher` in publisher.yml config file that comes from BlackKnight or pass sMaxAge as a param.
  */
 exports.isomorphicRoutes = function isomorphicRoutes(
   app,
@@ -314,10 +316,12 @@ exports.isomorphicRoutes = function isomorphicRoutes(
     prerenderServiceUrl = "",
     redirectToLowercaseSlugs = false,
     shouldEncodeAmpUri,
-    sMaxAge = "900",
+    sMaxAge = 900,
   }
 ) {
   const withConfig = withConfigPartial(getClient, logError, publisherConfig, configWrapper);
+
+  sMaxAge = parseInt(get(publisherConfig, ["publisher", "isomorphicRoutesSmaxage"], sMaxAge));
 
   pickComponent = makePickComponentSync(pickComponent);
   loadData = wrapLoadDataWithMultiDomain(publisherConfig, loadData, 2);

--- a/server/routes.js
+++ b/server/routes.js
@@ -275,7 +275,7 @@ function getWithConfig(app, route, handler, opts = {}) {
  * @param {Array<object>|function} opts.redirectUrls An array or async function which used to render the redirect url provided in the array of object - >ex- REDIRECT_URLS = [{sourceUrl: "/tag/:tagSlug",destinationUrl: "/topic/:tagSlug",statusCode: 301,}]
  * @param {boolean|function} redirectToLowercaseSlugs If set or evaluates to true, then for every story-page request having capital latin letters in the slug, it responds with a 301 redirect to the lowercase slug URL. (default: true)
  * @param {boolean|function} shouldEncodeAmpUri If set to true, then for every story-page request the slug will be encoded, in case of a vernacular slug this should be set to false. Receives path as param (default: true)
- * @param {number} sMaxAge Overrides the s-maxage value, the default value is set to 900 seconds. We can set `isomorphicRoutesSmaxage: 9000` under `publisher` in publisher.yml config file that comes from BlackKnight or pass sMaxAge as a param.
+ * @param {number} sMaxAge Overrides the s-maxage value, the default value is set to 900 seconds. We can set `isomorphicRoutesSmaxage: 900` under `publisher` in publisher.yml config file that comes from BlackKnight or pass sMaxAge as a param.
  */
 exports.isomorphicRoutes = function isomorphicRoutes(
   app,

--- a/server/routes.js
+++ b/server/routes.js
@@ -89,7 +89,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   app.all("/api/*", sketchesProxy);
   app.all("/login", sketchesProxy);
-  app.all("/qlitics.js", (exclude) => sketchesProxy(exclude));
+  app.all("/qlitics.js", sketchesProxy);
   app.all("/auth.form", sketchesProxy);
   app.all("/auth.callback", sketchesProxy);
   app.all("/auth", sketchesProxy);

--- a/server/routes.js
+++ b/server/routes.js
@@ -60,6 +60,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   apiProxy.on("proxyReq", (proxyReq, req, res, options) => {
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
+    res.setHeader("Cache-Control", "public,s-maxage=800");
   });
 
   const sketchesProxy = (req, res) => apiProxy.web(req, res);

--- a/server/routes.js
+++ b/server/routes.js
@@ -60,7 +60,6 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   apiProxy.on("proxyReq", (proxyReq, req, res, options) => {
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
-    
   });
 
   const sketchesProxy = (req, res) => apiProxy.web(req, res);

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,8 +69,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   parseInt(sMaxAge) &&
     apiProxy.on("proxyRes", function (proxyRes, req) {
-      const pathName = get(req, ["originalUrl"], "");
-      const checkForExcludeRoutes = excludeRoutes.every((item) => pathName.includes(item));
+      const pathName = get(req, ["originalUrl"], "").split("?")[0];
+      const checkForExcludeRoutes = excludeRoutes.every((item) => item !== pathName);
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
       if (checkForExcludeRoutes && getCacheControl.includes("public")) {
         proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -70,9 +70,10 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
       console.log("RAW Response from the target11111111", proxyRes.headers["cache-control"]);
 
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "").split(",")[0];
-      console.log("getCacheControl-------=====", getCacheControl);
+      console.log("req.originalUrl----", req.originalUrl);
+      console.log("req.url-----------", req.url);
 
-      if (req.originalUrl !== "/api/v1/breaking-news" && getCacheControl !== "private") {
+      if (req.originalUrl !== "/api/v1/breaking-news" || getCacheControl !== "private") {
         proxyRes.headers[
           "cache-control"
         ] = `public,max-age=15,s-maxage=${sMaxAge},stale-while-revalidate=300,stale-if-error=7200`;

--- a/server/routes.js
+++ b/server/routes.js
@@ -65,15 +65,15 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
   });
 
-  sMaxAge = get(config, ["publisher", "upstreamRoutesSmaxage"], sMaxAge);
+  const _sMaxAge = get(config, ["publisher", "upstreamRoutesSmaxage"], sMaxAge);
 
-  parseInt(sMaxAge) &&
+  parseInt(_sMaxAge) &&
     apiProxy.on("proxyRes", function (proxyRes, req) {
       const pathName = get(req, ["originalUrl"], "").split("?")[0];
       const checkForExcludeRoutes = excludeRoutes.every((item) => item !== pathName);
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
       if (checkForExcludeRoutes && getCacheControl.includes("public")) {
-        proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);
+        proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${_sMaxAge}`);
       }
     });
 
@@ -321,7 +321,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
 ) {
   const withConfig = withConfigPartial(getClient, logError, publisherConfig, configWrapper);
 
-  sMaxAge = parseInt(get(publisherConfig, ["publisher", "isomorphicRoutesSmaxage"], sMaxAge));
+  const _sMaxAge = parseInt(get(publisherConfig, ["publisher", "isomorphicRoutesSmaxage"], sMaxAge));
 
   pickComponent = makePickComponentSync(pickComponent);
   loadData = wrapLoadDataWithMultiDomain(publisherConfig, loadData, 2);
@@ -402,7 +402,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
       appVersion,
       cdnProvider,
       redirectToLowercaseSlugs,
-      sMaxAge,
+      sMaxAge: _sMaxAge,
     })
   );
 
@@ -427,7 +427,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
         mobileConfigFields,
         cdnProvider,
         redirectToLowercaseSlugs,
-        sMaxAge,
+        sMaxAge: _sMaxAge,
       })
     );
   }
@@ -460,7 +460,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
             cdnProvider,
             oneSignalServiceWorkers,
             publisherConfig,
-            sMaxAge,
+            sMaxAge: _sMaxAge,
           },
           route
         )
@@ -488,12 +488,12 @@ exports.isomorphicRoutes = function isomorphicRoutes(
       shouldEncodeAmpUri,
       oneSignalServiceWorkers,
       publisherConfig,
-      sMaxAge,
+      sMaxAge: _sMaxAge,
     })
   );
 
   if (redirectRootLevelStories) {
-    app.get("/:storySlug", withConfig(redirectStory, { logError, cdnProvider, sMaxAge }));
+    app.get("/:storySlug", withConfig(redirectStory, { logError, cdnProvider, sMaxAge: _sMaxAge }));
   }
 
   if (handleCustomRoute) {
@@ -505,7 +505,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
         logError,
         seo,
         cdnProvider,
-        sMaxAge,
+        sMaxAge: _sMaxAge,
       })
     );
   }

--- a/server/routes.js
+++ b/server/routes.js
@@ -67,12 +67,12 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   const _sMaxAge = get(config, ["publisher", "upstreamRoutesSmaxage"], sMaxAge);
 
-  parseInt(_sMaxAge) &&
+  parseInt(_sMaxAge) > 0 &&
     apiProxy.on("proxyRes", function (proxyRes, req) {
       const pathName = get(req, ["originalUrl"], "").split("?")[0];
-      const checkForExcludeRoutes = excludeRoutes.every((item) => item !== pathName);
+      const checkForExcludeRoutes = excludeRoutes.includes(pathName);
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
-      if (checkForExcludeRoutes && getCacheControl.includes("public")) {
+      if (!checkForExcludeRoutes && getCacheControl.includes("public")) {
         proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${_sMaxAge}`);
       }
     });

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,7 +69,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     apiProxy.on("proxyRes", function (proxyRes, req, res) {
       const pathName = get(req, ["originalUrl"], "").split("?")[0];
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
-      if (pathName !== "/api/v1/breaking-news" && getCacheControl.includes("public")) {
+      if (pathName !== "/qlitics.js" && pathName !== "/api/v1/breaking-news" && getCacheControl.includes("public")) {
         proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);
       }
     });

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,8 +69,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   parseInt(sMaxAge) &&
     apiProxy.on("proxyRes", function (proxyRes, req) {
-      const pathName = get(req, ["originalUrl"], "").split("?")[0];
-      const checkForExcludeRoutes = excludeRoutes.every((item) => item !== pathName);
+      const pathName = get(req, ["originalUrl"], "");
+      const checkForExcludeRoutes = excludeRoutes.every((item) => pathName.includes(item));
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
       if (checkForExcludeRoutes && getCacheControl.includes("public")) {
         proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);

--- a/server/routes.js
+++ b/server/routes.js
@@ -65,7 +65,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     proxyReq.setHeader("Host", getClient(req.hostname).getHostname());
   });
 
-  typeof sMaxAge === "number" &&
+  parseInt(sMaxAge) &&
     apiProxy.on("proxyRes", function (proxyRes, req, res) {
       const pathName = get(req, ["originalUrl"], "").split("?")[0];
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,9 +69,6 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     apiProxy.on("proxyRes", function (proxyRes, req, res) {
       const getBreakingNewsPath = get(req, ["originalUrl"], "").split("?")[0];
       const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
-      console.log("getCacheControl----------", getCacheControl);
-      console.log("getBreakingNewsPath-------", getBreakingNewsPath);
-
       if (getBreakingNewsPath !== "/api/v1/breaking-news" && getCacheControl.includes("public")) {
         proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);
       }

--- a/server/routes.js
+++ b/server/routes.js
@@ -67,16 +67,13 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   sMaxAge &&
     apiProxy.on("proxyRes", function (proxyRes, req, res) {
-      console.log("RAW Response from the target11111111", proxyRes.headers["cache-control"]);
+      const getBreakingNewsPath = get(req, ["originalUrl"], "").split("?")[0];
+      const getCacheControl = get(proxyRes, ["headers", "cache-control"], "");
+      console.log("getCacheControl----------", getCacheControl);
+      console.log("getBreakingNewsPath-------", getBreakingNewsPath);
 
-      const getCacheControl = get(proxyRes, ["headers", "cache-control"], "").split(",")[0];
-      console.log("req.originalUrl----", req.originalUrl);
-      console.log("req.url-----------", req.url);
-
-      if (req.originalUrl !== "/api/v1/breaking-news" || getCacheControl !== "private") {
-        proxyRes.headers[
-          "cache-control"
-        ] = `public,max-age=15,s-maxage=${sMaxAge},stale-while-revalidate=300,stale-if-error=7200`;
+      if (getBreakingNewsPath !== "/api/v1/breaking-news" && getCacheControl.includes("public")) {
+        proxyRes.headers["cache-control"] = getCacheControl.replace(/s-maxage=\d*/g, `s-maxage=${sMaxAge}`);
       }
     });
 

--- a/test/integration/sketches-proxy-test.js
+++ b/test/integration/sketches-proxy-test.js
@@ -128,7 +128,7 @@ describe("Sketches Proxy", function () {
         baseUrl: "https://www.foo.com",
       };
     }
-    function buildApp(sMaxAge = "", { app = express() } = {}) {
+    function buildApp(sMaxAge, { app = express() } = {}) {
       upstreamQuintypeRoutes(app, {
         config: {
           sketches_host: `https://demo.quintype.io`,
@@ -138,13 +138,13 @@ describe("Sketches Proxy", function () {
         forwardAmp: true,
         forwardFavicon: true,
         publisherConfig: {},
-        sMaxAge: `${sMaxAge}`,
+        sMaxAge: sMaxAge,
       });
       return app;
     }
 
     it("Override the s-maxage cache header when sMaxAge value is present", function (done) {
-      const sMaxAge = "900";
+      const sMaxAge = 900;
       supertest(buildApp(sMaxAge))
         .get("/api/v1/config")
         .expect(200)
@@ -156,7 +156,7 @@ describe("Sketches Proxy", function () {
     });
 
     it("Does not override the s-maxage cache header if cacheability is Private", function (done) {
-      const sMaxAge = "900";
+      const sMaxAge = 900;
       supertest(buildApp(sMaxAge))
         .get("/api/auth/v1/users/me")
         .then((res) => {
@@ -167,7 +167,7 @@ describe("Sketches Proxy", function () {
     });
 
     it("Does not override the s-maxage cache header for Breaking News", function (done) {
-      const sMaxAge = "900";
+      const sMaxAge = 900;
       supertest(buildApp(sMaxAge))
         .get("/api/v1/breaking-news")
         .then((res) => {

--- a/test/integration/sketches-proxy-test.js
+++ b/test/integration/sketches-proxy-test.js
@@ -1,10 +1,7 @@
 const assert = require("assert");
 const express = require("express");
 
-const {
-  upstreamQuintypeRoutes,
-  mountQuintypeAt,
-} = require("../../server/routes");
+const { upstreamQuintypeRoutes, mountQuintypeAt } = require("../../server/routes");
 const supertest = require("supertest");
 
 describe("Sketches Proxy", function () {
@@ -114,6 +111,79 @@ describe("Sketches Proxy", function () {
           assert.equal("GET", method);
           assert.equal("/api/v1/config", url);
           assert.equal("127.0.0.1", host);
+        })
+        .then(done);
+    });
+  });
+
+  describe("Override the s-maxage cache header", function () {
+    function getClientStub(hostname) {
+      return {
+        getHostname: () => "demo.quintype.io",
+        getConfig: () =>
+          Promise.resolve({
+            foo: "bar",
+            "sketches-host": "https://www.foo.com",
+          }),
+        baseUrl: "https://www.foo.com",
+      };
+    }
+    function buildApp(sMaxAge = "", { app = express() } = {}) {
+      upstreamQuintypeRoutes(app, {
+        config: {
+          sketches_host: `https://demo.quintype.io`,
+        },
+        getClient: getClientStub,
+        extraRoutes: ["/custom-route"],
+        forwardAmp: true,
+        forwardFavicon: true,
+        publisherConfig: {},
+        sMaxAge: `${sMaxAge}`,
+      });
+      return app;
+    }
+
+    it("Override the s-maxage cache header when sMaxAge value is present", function (done) {
+      const sMaxAge = "900";
+      supertest(buildApp(sMaxAge))
+        .get("/api/v1/config")
+        .expect(200)
+        .then((res) => {
+          const cacheControl = res.headers["cache-control"];
+          assert.equal(cacheControl, "public,max-age=15,s-maxage=900,stale-while-revalidate=300,stale-if-error=7200");
+        })
+        .then(done);
+    });
+
+    it("Does not override the s-maxage cache header if cacheability is Private", function (done) {
+      const sMaxAge = "900";
+      supertest(buildApp(sMaxAge))
+        .get("/api/auth/v1/users/me")
+        .then((res) => {
+          const cacheControl = res.headers["cache-control"];
+          assert.equal(cacheControl, "private,no-cache,no-store");
+        })
+        .then(done);
+    });
+
+    it("Does not override the s-maxage cache header for Breaking News", function (done) {
+      const sMaxAge = "900";
+      supertest(buildApp(sMaxAge))
+        .get("/api/v1/breaking-news")
+        .then((res) => {
+          const cacheControl = res.headers["cache-control"];
+          assert.equal(cacheControl, "public,max-age=15,s-maxage=240,stale-while-revalidate=300,stale-if-error=7200");
+        })
+        .then(done);
+    });
+
+    it("if sMaxAge value is not present, do not override cache headers", function (done) {
+      supertest(buildApp())
+        .get("/api/v1/config")
+        .expect(200)
+        .then((res) => {
+          const cacheControl = res.headers["cache-control"];
+          assert.equal(cacheControl, "public,max-age=15,s-maxage=240,stale-while-revalidate=300,stale-if-error=7200");
         })
         .then(done);
     });


### PR DESCRIPTION
It is observed that the below requests have a short TTL. We need to add the custom TTL on these

Eg: "/api/*, /sitemap/*, /rss-feed" etc.

Note: do not override `s-maxage`  for breaking news, qlitics and if  the cacheability is Private
Fetch the s-maxage value from BK for both isomorphic and upstream routes.

https://github.com/quintype/ace-planning/issues/488


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
