### PR TITLE
chore(dep): bump quintype amp dependencies from 2.4.11 to 2.4.12 ⚡

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.2",
+  "version": "6.1.3-amp-logo.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.12-visual-story-logo.2",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.2.tgz",
-      "integrity": "sha512-VDLsZg+/XSK0rw5U1wJmQph1q9j5HWX/a1KlJtuLswcC+Z2z5iij37aIl4lwUey7/SFG3+scZly4UJIfs4aE5g==",
+      "version": "2.4.12-visual-story-logo.3",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.3.tgz",
+      "integrity": "sha512-TsIir37yjtHGSn/16m/GMeZ3E8tFDcwSI54XKOYkuX+bFfhwH287ZtzQX9dGs9P/IKvJkXfcKYXINwrJajosiA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.12-visual-story-logo.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.1.tgz",
-      "integrity": "sha512-+B2lQaeReVRSYj3trIhBQG2hRjohrGNUTTq4EMa1tYNo+6aGCcvx8ZWddAqMQwMOzZ5e64ntTq0Em0fkZft6Mg==",
+      "version": "2.4.12-visual-story-logo.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.2.tgz",
+      "integrity": "sha512-VDLsZg+/XSK0rw5U1wJmQph1q9j5HWX/a1KlJtuLswcC+Z2z5iij37aIl4lwUey7/SFG3+scZly4UJIfs4aE5g==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.11.tgz",
-      "integrity": "sha512-loj+51zzY5zOKAKMrqw2wXRPFPNzc34vJmqisK90dIK8GPPdXFVGVBgSXR70Vgvvt9sZvU21CmBhAFkyHpCJeQ==",
+      "version": "2.4.12-visual-story-logo.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.0.tgz",
+      "integrity": "sha512-Tqq6kebYxq9whOEFHptrfanH5eXBNBP25KC6fqKTGbiLx7uQpl5qHRlnMH8QnRWEYIx7rkE5gQFvi6K+UguYRQ==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.12-visual-story-logo.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.0.tgz",
-      "integrity": "sha512-Tqq6kebYxq9whOEFHptrfanH5eXBNBP25KC6fqKTGbiLx7uQpl5qHRlnMH8QnRWEYIx7rkE5gQFvi6K+UguYRQ==",
+      "version": "2.4.12-visual-story-logo.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.1.tgz",
+      "integrity": "sha512-+B2lQaeReVRSYj3trIhBQG2hRjohrGNUTTq4EMa1tYNo+6aGCcvx8ZWddAqMQwMOzZ5e64ntTq0Em0fkZft6Mg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.2",
+  "version": "6.1.3-amp-logo.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.1",
+  "version": "6.1.3-amp-logo.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quintype/amp": {
-      "version": "2.4.12-visual-story-logo.3",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12-visual-story-logo.3.tgz",
-      "integrity": "sha512-TsIir37yjtHGSn/16m/GMeZ3E8tFDcwSI54XKOYkuX+bFfhwH287ZtzQX9dGs9P/IKvJkXfcKYXINwrJajosiA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.12.tgz",
+      "integrity": "sha512-KZcnixp9QhuUt71bHo46wrAIRKywW2MVAzRNIbM0xgrQklJLuIU65E0EdzTlZVOXNK7YfYX28W5XU2X9EZVZzA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.0",
+  "version": "6.1.3-amp-logo.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.0",
-    "@quintype/amp": "^2.4.12-visual-story-logo.2",
+    "@quintype/amp": "^2.4.12-visual-story-logo.3",
     "@quintype/backend": "^2.1.0",
     "@quintype/components": "^2.31.2",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.0",
-    "@quintype/amp": "^2.4.12-visual-story-logo.3",
+    "@quintype/amp": "^2.4.12",
     "@quintype/backend": "^2.1.0",
     "@quintype/components": "^2.31.2",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.1",
+  "version": "6.1.3-amp-logo.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.2",
+  "version": "6.1.3-amp-logo.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.0",
+  "version": "6.1.3-amp-logo.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.0",
-    "@quintype/amp": "^2.4.12-visual-story-logo.1",
+    "@quintype/amp": "^2.4.12-visual-story-logo.2",
     "@quintype/backend": "^2.1.0",
     "@quintype/components": "^2.31.2",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.0",
-    "@quintype/amp": "^2.4.11",
+    "@quintype/amp": "^2.4.12-visual-story-logo.0",
     "@quintype/backend": "^2.1.0",
     "@quintype/components": "^2.31.2",
     "@quintype/prerender-node": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "6.1.3-amp-logo.2",
+  "version": "6.1.3-amp-logo.3",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.0",
-    "@quintype/amp": "^2.4.12-visual-story-logo.0",
+    "@quintype/amp": "^2.4.12-visual-story-logo.1",
     "@quintype/backend": "^2.1.0",
     "@quintype/components": "^2.31.2",
     "@quintype/prerender-node": "^3.2.24",


### PR DESCRIPTION
Updated Quintype amp dependencies from 2.4.11 to 2.4.12. 

Ticket - https://github.com/quintype/ace-planning/issues/558