### PR TITLE
Rss hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.7.1",
+  "version": "7.7.2-rss-hotfix.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.7.1",
+      "version": "7.7.2-rss-hotfix.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.7.1",
+  "version": "7.7.2-rss-hotfix.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -96,6 +96,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     "/stories.rss",
     "/api/v1/collections/:slug.rss",
     "/api/v1/advanced-search",
+    "/api/instant-articles.rss",
   ];
 
   app.all("/api/*", sketchesProxy);


### PR DESCRIPTION
Exclude `/api/instant-articles.rss` from adding cache tags