### PR TITLE
fix: remove prerender query param after the prerender check

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -345,6 +345,7 @@ exports.isomorphicRoutes = function isomorphicRoutes(
   if (prerenderServiceUrl) {
     app.use((req, res, next) => {
       if (req.query.prerender) {
+        delete req.query.prerender;
         try {
           // eslint-disable-next-line global-require
           prerender.set("prerenderServiceUrl", prerenderServiceUrl)(req, res, next);


### PR DESCRIPTION
Reference : https://github.com/quintype/ace-planning/issues/378