### PR TITLE
fix: seo metadata not coming in static pages

### DIFF
--- a/server/handlers/custom-route-handler.js
+++ b/server/handlers/custom-route-handler.js
@@ -42,6 +42,8 @@ function writeStaticPageResponse(res, url, page, result, { config, renderLayout,
     store,
     seoTags,
     disableAjaxNavigation: true,
+    enableHeader: page.metadata.header,
+    enableFooter: page.metadata.footer,
   });
 }
 
@@ -91,20 +93,17 @@ exports.customRouteHandler = function customRouteHandler(
         });
         addStaticPageMimeType({ res, page });
 
-        if (page.metadata.header || page.metadata.footer) {
-          return loadData("custom-static-page", {}, config, client, {
-            host: req.hostname,
-            domainSlug,
-            cookies: req.cookies,
-          }).then((response) => {
-            return writeStaticPageResponse(res, url, page.page, response, {
-              config,
-              renderLayout,
-              seo,
-            });
+        return loadData("custom-static-page", {}, config, client, {
+          host: req.hostname,
+          domainSlug,
+          cookies: req.cookies,
+        }).then((response) => {
+          return writeStaticPageResponse(res, url, page.page, response, {
+            config,
+            renderLayout,
+            seo,
           });
-        }
-        return res.send(page.content);
+        });
       }
 
       return next();


### PR DESCRIPTION
Reference: https://github.com/quintype/ace-planning/issues/789

**Issue**: In static pages, seo metadata is not coming when the header and footer are not selected in the bold.

**Reason for this issue**: There is a condition in the code which checks for the header, footer and renders the layout only if both or either of them are selected.

**Fix**: Remove that condition and add a toggle to render header and footer based on what is selected in bold.