### PR TITLE
fix:  custom pages cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3446,6 +3446,7 @@
       "version": "1.40.9",
       "resolved": "https://registry.npmjs.org/@quintype/seo/-/seo-1.40.9.tgz",
       "integrity": "sha512-QlvyTRc87IXxw1KBtqlO9n6wzNdBqKJaqDZvH8wyql/YgxXP0CK6P10yA5wZXod9XnzmcHJYjT+uprrQmdX+DQ==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^2.17.0",
         "date-fns-tz": "^1.1.1",
@@ -4336,6 +4337,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4351,7 +4354,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -28962,6 +28967,7 @@
       "version": "1.40.9",
       "resolved": "https://registry.npmjs.org/@quintype/seo/-/seo-1.40.9.tgz",
       "integrity": "sha512-QlvyTRc87IXxw1KBtqlO9n6wzNdBqKJaqDZvH8wyql/YgxXP0CK6P10yA5wZXod9XnzmcHJYjT+uprrQmdX+DQ==",
+      "peer": true,
       "requires": {
         "date-fns": "^2.17.0",
         "date-fns-tz": "^1.1.1",
@@ -29786,15 +29792,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -29806,7 +29811,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.18.9",
+  "version": "7.18.10-fix-staticpages.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.18.9",
+      "version": "7.18.10-fix-staticpages.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.18.9",
+  "version": "7.18.10-fix-staticpages.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/caching.js
+++ b/server/caching.js
@@ -61,5 +61,5 @@ exports.sorterToCacheKey = function sorterToCacheKey(
  * @returns {string} The cache key
  */
 exports.customUrlToCacheKey = function customUrlToCacheKey(publisherId, page) {
-  return `u/${publisherId}/${page.id}`;
+  return `sp/${publisherId}/${page.id}`;
 };

--- a/test/integration/custom-route-handler-test.js
+++ b/test/integration/custom-route-handler-test.js
@@ -131,8 +131,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", /Accept\-Encoding/)
-      .expect("Surrogate-Key", "u/42/101")
-      .expect("Cache-Tag", "u/42/101")
+      .expect("Surrogate-Key", "sp/42/101")
+      .expect("Cache-Tag", "sp/42/101")
       .expect(301, done);
   });
 
@@ -149,8 +149,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", /Accept\-Encoding/)
-      .expect("Surrogate-Key", "u/42/102")
-      .expect("Cache-Tag", "u/42/102")
+      .expect("Surrogate-Key", "sp/42/102")
+      .expect("Cache-Tag", "sp/42/102")
       .expect(302, done);
   });
 
@@ -193,8 +193,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", "Accept-Encoding")
-      .expect("Surrogate-Key", "u/42/104")
-      .expect("Cache-Tag", "u/42/104")
+      .expect("Surrogate-Key", "sp/42/104")
+      .expect("Cache-Tag", "sp/42/104")
       .expect(200)
       .then((res) => {
         assert.equal(
@@ -263,8 +263,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", /Accept\-Encoding/)
-      .expect("Surrogate-Key", "u/42/105")
-      .expect("Cache-Tag", "u/42/105")
+      .expect("Surrogate-Key", "sp/42/105")
+      .expect("Cache-Tag", "sp/42/105")
       .expect(301, done);
   });
 
@@ -280,8 +280,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", /Accept\-Encoding/)
-      .expect("Surrogate-Key", "u/42/105")
-      .expect("Cache-Tag", "u/42/105")
+      .expect("Surrogate-Key", "sp/42/105")
+      .expect("Cache-Tag", "sp/42/105")
       .expect("Content-Type", "text/plain; charset=utf-8")
       .expect(200, done);
   });
@@ -298,8 +298,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", "Accept-Encoding")
-      .expect("Surrogate-Key", "u/42/104")
-      .expect("Cache-Tag", "u/42/104")
+      .expect("Surrogate-Key", "sp/42/104")
+      .expect("Cache-Tag", "sp/42/104")
       .expect("Content-Type", "text/html; charset=utf-8")
       .expect(200, done);
   });

--- a/test/integration/custom-route-handler-test.js
+++ b/test/integration/custom-route-handler-test.js
@@ -168,8 +168,8 @@ describe("Custom Route Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", "Accept-Encoding")
-      .expect("Surrogate-Key", "u/42/103")
-      .expect("Cache-Tag", "u/42/103")
+      .expect("Surrogate-Key", "sp/42/103")
+      .expect("Cache-Tag", "sp/42/103")
       .expect(200)
       .then((res) => {
         const response = JSON.parse(res.text);

--- a/test/integration/url-redirect-test.js
+++ b/test/integration/url-redirect-test.js
@@ -651,8 +651,8 @@ describe("Redirect Routes Handler", function () {
         "public,max-age=15,s-maxage=900,stale-while-revalidate=1000,stale-if-error=14400"
       )
       .expect("Vary", /Accept\-Encoding/)
-      .expect("Surrogate-Key", "u/42/102")
-      .expect("Cache-Tag", "u/42/102")
+      .expect("Surrogate-Key", "sp/42/102")
+      .expect("Cache-Tag", "sp/42/102")
       .expect(302, done);
   });
 

--- a/test/unit/api-client-test.js
+++ b/test/unit/api-client-test.js
@@ -678,7 +678,7 @@ describe("ApiClient", function () {
   describe("Custom urls", function () {
     it("returns cache keys", function () {
       const page = CustomPath.build({ id: 101 });
-      assert.deepStrictEqual(["u/1/101"], page.cacheKeys(1));
+      assert.deepStrictEqual(["sp/1/101"], page.cacheKeys(1));
     });
 
     it("returns cache keys as null if page is invalid", function () {


### PR DESCRIPTION
# Description

ref: https://github.com/quintype/ace-planning/issues/814

Fixes # (issue-reference)

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Check the cache tag and surrogate keys on response headers for custom url routes.
it should be `sp/1/123 `and not `u/1/123`


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
