### PR TITLE
[fix]: Set header and redirect to https

### DIFF
--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -17,6 +17,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
       res.setHeader("Cache-Control", "private,no-cache,no-store,max-age=0");
       cdnProviderVal === "akamai" && res.setHeader("Edge-Control", "private,no-cache,no-store,max-age=0");
       res.setHeader("Vary", "Accept-Encoding");
+      res.setHeader("Strict-Transport-Security",`max-age=31536000; includeSubDomains; preload`);
       res.setHeader(
         "Content-Security-Policy",
         `default-src data: 'unsafe-inline' 'unsafe-eval' https: http:;` +
@@ -34,6 +35,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
     } else {
       if (networkOnly) {
         res.setHeader("Cache-Control", `public,s-maxage=${sMaxAge}`);
+        res.setHeader("Strict-Transport-Security",`max-age=31536000; includeSubDomains; preload`);
         res.setHeader(
           "Cloudflare-CDN-Cache-Control",
           `max-age=${sMaxAge}, stale-while-revalidate=1000, stale-if-error=14400`
@@ -44,6 +46,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
           "Cache-Control",
           `public,max-age=15,s-maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`
         );
+        res.setHeader("Strict-Transport-Security",`max-age=31536000; includeSubDomains; preload`);
         cdnProviderVal === "akamai" &&
           res.setHeader("Edge-Control", `public,maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`);
       }
@@ -57,6 +60,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
       cdnProviderVal === "akamai" && res.setHeader("Edge-Cache-Tag", _(cacheKeys).uniq().join(","));
 
       res.setHeader("Surrogate-Key", _(cacheKeys).uniq().join(" "));
+      res.setHeader("Strict-Transport-Security",`max-age=31536000; includeSubDomains; preload`);
       res.setHeader(
         "Content-Security-Policy",
         `default-src data: 'unsafe-inline' 'unsafe-eval' https: http:;` +
@@ -74,6 +78,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
     }
   } else {
     res.setHeader("Cache-Control", "public,max-age=15,s-maxage=60,stale-while-revalidate=150,stale-if-error=3600");
+    res.setHeader("Strict-Transport-Security",`max-age=31536000; includeSubDomains; preload`);
     cdnProviderVal === "akamai" &&
       res.setHeader("Edge-Control", "public,maxage=60,stale-while-revalidate=150,stale-if-error=3600");
     res.setHeader("Vary", "Accept-Encoding");

--- a/test/integration/isomorphic-handler-test.js
+++ b/test/integration/isomorphic-handler-test.js
@@ -250,6 +250,28 @@ describe("Isomorphic Handler", function () {
       .expect(200, done);
   });
 
+  it('should set Strict-Transport-Security header and redirect to HTTPS', async () => {
+    const app = createApp(
+      (pageType, params, config, client) =>
+        Promise.resolve({
+          pageType,
+          data: { text: "foobar", cacheKeys: ["foo", "bar"] },
+        }),
+      [{ pageType: "home-page", path: "/" }]
+    );
+
+    supertest(app)
+      .get('/')
+      .set('Host', 'foobar.com')
+      .set('X-Forwarded-Proto', 'http')
+      .then((res) => {
+        assert.equal('Strict-Transport-Security','max-age=31536000; includeSubDomains; preload' )
+        assert.equal(301, res.statusCode)
+        .expect(res.headers.location).toMatch(/^https:\/\/foobar.com/);
+       })
+      .then(done, done);
+  });
+
   it("it redirects on a 301", function (done) {
     const app = createApp(
       (pageType, params, config, client) =>


### PR DESCRIPTION
# Description

Ticket: [#815](https://github.com/quintype/ace-planning/issues/815)

Fixes # (issue-reference)
1. Strict transport security not enforced
2. Non - secure requests are not automatically upgraded to HTTPS | HSTS missing
Fixes above two vulnerabilities 

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We need to submit the domain for review by browser vendors.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
