### PR TITLE
hardcode ttl of 10min for topic page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3-topic-page-caching.1",
+  "version": "7.19.3-topic-page-caching.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.3-topic-page-caching.1",
+      "version": "7.19.3-topic-page-caching.2",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3-topic-page-caching.0",
+  "version": "7.19.3-topic-page-caching.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.3-topic-page-caching.0",
+      "version": "7.19.3-topic-page-caching.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.2",
+  "version": "7.19.3-topic-page-caching.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.2",
+      "version": "7.19.3-topic-page-caching.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.2",
+  "version": "7.19.3-topic-page-caching.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3-topic-page-caching.0",
+  "version": "7.19.3-topic-page-caching.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3-topic-page-caching.1",
+  "version": "7.19.3-topic-page-caching.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -47,7 +47,6 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
         );
         cdnProviderVal === "akamai" &&
           res.setHeader("Edge-Control", `public,maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`);
-        addCacheHeadersForTagPages({ pageType, res });
       }
 
       res.setHeader("Vary", "Accept-Encoding");
@@ -96,9 +95,3 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
   }
   return res;
 };
-
-function addCacheHeadersForTagPages({ pageType, res }) {
-  // platform doesn't provide cache tags to purge tag pages at the time of writing this, so hardcoding a ttl of 10 min
-  if (pageType === "tag-page")
-    res.setHeader("Cache-Control", `public,max-age=15,s-maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
-}

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -98,11 +98,8 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
 };
 
 function addCacheHeadersForTopicPages(req, res) {
-  const path = req ? req.path : "";
   // as of now, platform doesn't provide cache tags to purge tag pages so hardcoding a ttl of 10 min
-  if (path.startsWith("/topic")) {
+  const path = req ? req.path : "";
+  if (path.startsWith("/topic"))
     res.setHeader("Cache-Control", `public,max-age=15,s-maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
-    if (cdnProviderVal === "akamai")
-      res.setHeader("Edge-Control", `public,maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
-  }
 }

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -2,6 +2,7 @@ const { cache } = require("ejs");
 const _ = require("lodash");
 
 exports.addCacheHeadersToResult = function addCacheHeadersToResult({
+  req,
   res,
   cacheKeys,
   cdnProvider = "cloudflare",
@@ -91,6 +92,12 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
         `form-action https: http:;` +
         `block-all-mixed-content;`
     );
+  }
+  if (req.path.startsWith("/topic")) {
+    // as of now, platform doesn't provide cache tags to purge tag pages so hardcoding a ttl of 10 min
+    res.setHeader("Cache-Control", `public,max-age=15,s-maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
+    if (cdnProviderVal === "akamai")
+      res.setHeader("Edge-Control", `public,maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
   }
   return res;
 };

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -8,7 +8,6 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
   config,
   sMaxAge = "900",
   networkOnly = false,
-  pageType = "",
 }) {
   let cdnProviderVal = null;
   cdnProviderVal =

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -2,13 +2,13 @@ const { cache } = require("ejs");
 const _ = require("lodash");
 
 exports.addCacheHeadersToResult = function addCacheHeadersToResult({
-  req,
   res,
   cacheKeys,
   cdnProvider = "cloudflare",
   config,
   sMaxAge = "900",
   networkOnly = false,
+  pageType = "",
 }) {
   let cdnProviderVal = null;
   cdnProviderVal =
@@ -47,7 +47,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
         );
         cdnProviderVal === "akamai" &&
           res.setHeader("Edge-Control", `public,maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`);
-        addCacheHeadersForTopicPages(req, res);
+        addCacheHeadersForTagPages({ pageType, res });
       }
 
       res.setHeader("Vary", "Accept-Encoding");
@@ -97,9 +97,8 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
   return res;
 };
 
-function addCacheHeadersForTopicPages(req, res) {
-  // as of now, platform doesn't provide cache tags to purge tag pages so hardcoding a ttl of 10 min
-  const path = req ? req.path : "";
-  if (path.startsWith("/topic"))
+function addCacheHeadersForTagPages({ pageType, res }) {
+  // platform doesn't provide cache tags to purge tag pages at the time of writing this, so hardcoding a ttl of 10 min
+  if (pageType === "tag-page")
     res.setHeader("Cache-Control", `public,max-age=15,s-maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
 }

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -47,6 +47,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
         );
         cdnProviderVal === "akamai" &&
           res.setHeader("Edge-Control", `public,maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`);
+        addCacheHeadersForTopicPages(req, res);
       }
 
       res.setHeader("Vary", "Accept-Encoding");
@@ -93,11 +94,15 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
         `block-all-mixed-content;`
     );
   }
-  if (req.path.startsWith("/topic")) {
-    // as of now, platform doesn't provide cache tags to purge tag pages so hardcoding a ttl of 10 min
+  return res;
+};
+
+function addCacheHeadersForTopicPages(req, res) {
+  const path = req ? req.path : "";
+  // as of now, platform doesn't provide cache tags to purge tag pages so hardcoding a ttl of 10 min
+  if (path.startsWith("/topic")) {
     res.setHeader("Cache-Control", `public,max-age=15,s-maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
     if (cdnProviderVal === "akamai")
       res.setHeader("Edge-Control", `public,maxage=600,stale-while-revalidate=1000,stale-if-error=14400`);
   }
-  return res;
-};
+}

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -432,12 +432,11 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
 
     if (statusCode == 301 && result.data && result.data.location) {
       addCacheHeadersToResult({
-        pageType: store.getState().qt.pageType,
         res: res,
         cacheKeys: [customUrlToCacheKey(config["publisher-id"], "redirect")],
         cdnProvider: cdnProvider,
         config: config,
-        sMaxAge,
+        sMaxAge: result.pageType === "tag-page" ? 600 : sMaxAge,
       });
       return res.redirect(301, result.data.location);
     }
@@ -459,12 +458,11 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
 
     res.status(statusCode);
     addCacheHeadersToResult({
-      pageType: store.getState().qt.pageType,
       res: res,
       cacheKeys: _.get(result, ["data", "cacheKeys"]),
       cdnProvider: cdnProvider,
       config: config,
-      sMaxAge,
+      sMaxAge: result.pageType === "tag-page" ? 600 : sMaxAge,
     });
 
     if (preloadJs) {

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -432,6 +432,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
 
     if (statusCode == 301 && result.data && result.data.location) {
       addCacheHeadersToResult({
+        pageType: store.getState().qt.pageType,
         res: res,
         cacheKeys: [customUrlToCacheKey(config["publisher-id"], "redirect")],
         cdnProvider: cdnProvider,
@@ -458,7 +459,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
 
     res.status(statusCode);
     addCacheHeadersToResult({
-      req,
+      pageType: store.getState().qt.pageType,
       res: res,
       cacheKeys: _.get(result, ["data", "cacheKeys"]),
       cdnProvider: cdnProvider,

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -458,6 +458,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
 
     res.status(statusCode);
     addCacheHeadersToResult({
+      req,
       res: res,
       cacheKeys: _.get(result, ["data", "cacheKeys"]),
       cdnProvider: cdnProvider,


### PR DESCRIPTION
fixes https://github.com/quintype/page-builder/issues/2395

Context: platform doesn't have dedicated CDN cache keys for topic pages so FE was receiving stale data. So hardcoding a ttl of 10 min until platform makes a fix