### PR TITLE
Add render prop for Navbar-Header in AMP lib to add customizations from FE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "2.12.0-search-on-header.1",
+        "@quintype/amp": "^2.12.1",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.0-search-on-header.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.1.tgz",
-      "integrity": "sha512-Bdet9kr1JG1HF1Xo69eX2pTQwsDS5Lm4i3BUdFMOaD6O4ezZ0sM5IJDVPeU1ZunwXzuU5P48wCOQEdO/3dXpKg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
+      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.0-search-on-header.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.1.tgz",
-      "integrity": "sha512-Bdet9kr1JG1HF1Xo69eX2pTQwsDS5Lm4i3BUdFMOaD6O4ezZ0sM5IJDVPeU1ZunwXzuU5P48wCOQEdO/3dXpKg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
+      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.4-searc-on-header.0",
+  "version": "7.19.4-searc-on-header.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.4-searc-on-header.0",
+      "version": "7.19.4-searc-on-header.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "2.12.0-search-on-header.0",
+        "@quintype/amp": "2.12.0-search-on-header.1",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.0-search-on-header.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
-      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
+      "version": "2.12.0-search-on-header.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.1.tgz",
+      "integrity": "sha512-Bdet9kr1JG1HF1Xo69eX2pTQwsDS5Lm4i3BUdFMOaD6O4ezZ0sM5IJDVPeU1ZunwXzuU5P48wCOQEdO/3dXpKg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.0-search-on-header.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
-      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
+      "version": "2.12.0-search-on-header.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.1.tgz",
+      "integrity": "sha512-Bdet9kr1JG1HF1Xo69eX2pTQwsDS5Lm4i3BUdFMOaD6O4ezZ0sM5IJDVPeU1ZunwXzuU5P48wCOQEdO/3dXpKg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.12.0",
+        "@quintype/amp": "^2.12.1",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0.tgz",
-      "integrity": "sha512-Xd/0x5Dx7Sso4ecakOMo7cv2fnLcpft4D91gLWVmqRpt5qsx4V7uAcEZHBiqWVeZ/DwQwsNZOBjB4Q1qg5F3DQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
+      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0.tgz",
-      "integrity": "sha512-Xd/0x5Dx7Sso4ecakOMo7cv2fnLcpft4D91gLWVmqRpt5qsx4V7uAcEZHBiqWVeZ/DwQwsNZOBjB4Q1qg5F3DQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
+      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3",
+  "version": "7.19.4-searc-on-header.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.3",
+      "version": "7.19.4-searc-on-header.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.11.0",
+        "@quintype/amp": "2.12.0-search-on-header.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.11.0.tgz",
-      "integrity": "sha512-fmJKuOwzJt80SBuPO90ULTixfYgvMcoAjUFhUPJFw3xgU1ibB3WTm9ah9GTK3DUyHz2w7CSQ32EnYkWiZ/69Xg==",
+      "version": "2.12.0-search-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
+      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.11.0.tgz",
-      "integrity": "sha512-fmJKuOwzJt80SBuPO90ULTixfYgvMcoAjUFhUPJFw3xgU1ibB3WTm9ah9GTK3DUyHz2w7CSQ32EnYkWiZ/69Xg==",
+      "version": "2.12.0-search-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
+      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.12.0",
+    "@quintype/amp": "^2.12.1",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.4-searc-on-header.0",
+  "version": "7.19.4-searc-on-header.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "2.12.0-search-on-header.0",
+    "@quintype/amp": "2.12.0-search-on-header.1",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "2.12.0-search-on-header.1",
+    "@quintype/amp": "^2.12.1",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.3",
+  "version": "7.19.4-searc-on-header.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.11.0",
+    "@quintype/amp": "2.12.0-search-on-header.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",


### PR DESCRIPTION
# Description
we have search page on the header for normal pages which directs the user to the search page. The client (praja vani) wants the same to be replicated for AMP as well .

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/841#event-9196522028

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/433

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
