### PR TITLE
Image stretch issue on AMP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.12",
+  "version": "7.19.13-tpml-image-stretch-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.12",
+      "version": "7.19.13-tpml-image-stretch-issue.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7-tpml-image-stretch-issue.0",
+  "version": "7.19.7-tpml-image-stretch-issue.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.7-tpml-image-stretch-issue.0",
+      "version": "7.19.7-tpml-image-stretch-issue.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.12.1",
+        "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.2",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
-      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
+      "version": "2.12.2-tpml--img-stretch-issue.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.2.tgz",
+      "integrity": "sha512-bfOWKcdxHR+1QyM5l6/rn9TYyam1QJ1d0RLJPKpn3wyuQf4LO1GTlPnYAmVxfcOoHIEOiBtGS03+IoU8gvk51g==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.1.tgz",
-      "integrity": "sha512-+cZ2NtMnTMkTbCmPs6dfPqQmys98sOHCj2zJTv6CbCKrEhJXVfOLRPGSR4Yk9oS3LTi+YxFa1shf+jSxFw58MA==",
+      "version": "2.12.2-tpml--img-stretch-issue.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.2.tgz",
+      "integrity": "sha512-bfOWKcdxHR+1QyM5l6/rn9TYyam1QJ1d0RLJPKpn3wyuQf4LO1GTlPnYAmVxfcOoHIEOiBtGS03+IoU8gvk51g==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7-tpml-image-stretch-issue.1",
+  "version": "7.19.7-tpml-image-stretch-issue.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.7-tpml-image-stretch-issue.1",
+      "version": "7.19.7-tpml-image-stretch-issue.2",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.2",
+        "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.3",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.2-tpml--img-stretch-issue.2",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.2.tgz",
-      "integrity": "sha512-bfOWKcdxHR+1QyM5l6/rn9TYyam1QJ1d0RLJPKpn3wyuQf4LO1GTlPnYAmVxfcOoHIEOiBtGS03+IoU8gvk51g==",
+      "version": "2.12.2-tpml--img-stretch-issue.3",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.3.tgz",
+      "integrity": "sha512-15DH18u9A2XCS5mWZTGmgiNsIfA+7YB87HIhfPvyaQRmMAFYygKLr0iVichfJI/if5ypkO4pf3whetUZsPglvQ==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.2-tpml--img-stretch-issue.2",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.2.tgz",
-      "integrity": "sha512-bfOWKcdxHR+1QyM5l6/rn9TYyam1QJ1d0RLJPKpn3wyuQf4LO1GTlPnYAmVxfcOoHIEOiBtGS03+IoU8gvk51g==",
+      "version": "2.12.2-tpml--img-stretch-issue.3",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.3.tgz",
+      "integrity": "sha512-15DH18u9A2XCS5mWZTGmgiNsIfA+7YB87HIhfPvyaQRmMAFYygKLr0iVichfJI/if5ypkO4pf3whetUZsPglvQ==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7",
+  "version": "7.19.8-tpml-image-stretch-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.7",
+      "version": "7.19.8-tpml-image-stretch-issue.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
+        "@quintype/amp": "^2.17.2",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3276,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.17.2-tpml-image-stretch-issue.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
-      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2.tgz",
+      "integrity": "sha512-rqC+syWOmL7FNdLCv9gSMffSewizllHLxCc3MoXM4v6NQNch6YxMCSJs1EclCQdU7cLRFwyjFWCjsCk6WCbZKw==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28817,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.17.2-tpml-image-stretch-issue.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
-      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2.tgz",
+      "integrity": "sha512-rqC+syWOmL7FNdLCv9gSMffSewizllHLxCc3MoXM4v6NQNch6YxMCSJs1EclCQdU7cLRFwyjFWCjsCk6WCbZKw==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.8",
+  "version": "7.19.9-tpml-image-stretch-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.8",
+      "version": "7.19.9-tpml-image-stretch-issue.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.12.2",
+        "@quintype/amp": "^2.12.3-tpml--img-stretch-issue.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3276,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2.tgz",
-      "integrity": "sha512-08h5Chcv56VK6bSIx9/SN60jc8QZJH7nfGekQYrJ9vW1pB4u40McjVfNf3eB9kxxAW6gITc39h4UUcyFo7DNeQ==",
+      "version": "2.12.3-tpml--img-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.3-tpml--img-stretch-issue.0.tgz",
+      "integrity": "sha512-CI8hydqoMSwt7vtZpM/juhXDRPfu9TpvP/8CLvXfCUR7VgdFXablu1qTaBILbvy3a+Ql9Pp8rZZ2+Y4TFX6wPg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28817,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2.tgz",
-      "integrity": "sha512-08h5Chcv56VK6bSIx9/SN60jc8QZJH7nfGekQYrJ9vW1pB4u40McjVfNf3eB9kxxAW6gITc39h4UUcyFo7DNeQ==",
+      "version": "2.12.3-tpml--img-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.3-tpml--img-stretch-issue.0.tgz",
+      "integrity": "sha512-CI8hydqoMSwt7vtZpM/juhXDRPfu9TpvP/8CLvXfCUR7VgdFXablu1qTaBILbvy3a+Ql9Pp8rZZ2+Y4TFX6wPg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.15.0-tpml--img-stretch-issue.0",
+        "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3276,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.15.0-tpml--img-stretch-issue.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.15.0-tpml--img-stretch-issue.0.tgz",
-      "integrity": "sha512-djduFcpL+P22QdKAxXoNP/9XDsNp0cL5JsFSMbKSq5baiYOghjiSgZOEYvNIB0ookiwea4uxvo9uLmm8yK8tOQ==",
+      "version": "2.17.2-tpml-image-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
+      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28817,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.15.0-tpml--img-stretch-issue.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.15.0-tpml--img-stretch-issue.0.tgz",
-      "integrity": "sha512-djduFcpL+P22QdKAxXoNP/9XDsNp0cL5JsFSMbKSq5baiYOghjiSgZOEYvNIB0ookiwea4uxvo9uLmm8yK8tOQ==",
+      "version": "2.17.2-tpml-image-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
+      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.17.1",
+        "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3276,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.1.tgz",
-      "integrity": "sha512-vhW+EZIFB9S+VJNHo9UvcemaXv5ze9cS+z+SYj14408IlQFTpy0tG6djk56v4Q16Vd+q7EKEDgzEDkDvwm0wfA==",
+      "version": "2.17.2-tpml-image-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
+      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28817,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.1.tgz",
-      "integrity": "sha512-vhW+EZIFB9S+VJNHo9UvcemaXv5ze9cS+z+SYj14408IlQFTpy0tG6djk56v4Q16Vd+q7EKEDgzEDkDvwm0wfA==",
+      "version": "2.17.2-tpml-image-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.2-tpml-image-stretch-issue.0.tgz",
+      "integrity": "sha512-YJkIyJCKwrnnLFiEsdrLWXny8b5dj/ioYGmO4RORqTccQGaGUlK7cbsskvIV+NtgrcFUJEIvUrN7/8K/PYQWVA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.14.0",
+        "@quintype/amp": "^2.15.0-tpml--img-stretch-issue.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3276,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.0.tgz",
-      "integrity": "sha512-+O7Wu3HBiXUDA00GEHL+wE27H4UpWh+lEpSNwhZnXw4CYaomJD17CaP+PZ7GOmzCc1fAdIvITIne6woCy2urhQ==",
+      "version": "2.15.0-tpml--img-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.15.0-tpml--img-stretch-issue.0.tgz",
+      "integrity": "sha512-djduFcpL+P22QdKAxXoNP/9XDsNp0cL5JsFSMbKSq5baiYOghjiSgZOEYvNIB0ookiwea4uxvo9uLmm8yK8tOQ==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28817,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.0.tgz",
-      "integrity": "sha512-+O7Wu3HBiXUDA00GEHL+wE27H4UpWh+lEpSNwhZnXw4CYaomJD17CaP+PZ7GOmzCc1fAdIvITIne6woCy2urhQ==",
+      "version": "2.15.0-tpml--img-stretch-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.15.0-tpml--img-stretch-issue.0.tgz",
+      "integrity": "sha512-djduFcpL+P22QdKAxXoNP/9XDsNp0cL5JsFSMbKSq5baiYOghjiSgZOEYvNIB0ookiwea4uxvo9uLmm8yK8tOQ==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.6",
+  "version": "7.19.7-tpml-image-stretch-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.6",
+      "version": "7.19.7-tpml-image-stretch-issue.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.3",
+        "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.4",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -355,18 +355,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
@@ -439,11 +427,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -479,9 +467,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -551,10 +539,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1509,12 +1505,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.20.7.tgz",
+      "integrity": "sha512-Jq14o707UCRcGrdWa3qyA9TMoa/dMi9GfrphmwsppuZ3jxbDqRXHrQkjLN87sopIV3Zlp8SRZS48+S9ABcmC7g==",
       "dependencies": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1918,11 +1913,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
-      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.21.5",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1993,17 +1989,17 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -3280,9 +3276,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.12.2-tpml--img-stretch-issue.3",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.3.tgz",
-      "integrity": "sha512-15DH18u9A2XCS5mWZTGmgiNsIfA+7YB87HIhfPvyaQRmMAFYygKLr0iVichfJI/if5ypkO4pf3whetUZsPglvQ==",
+      "version": "2.12.2-tpml--img-stretch-issue.4",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.4.tgz",
+      "integrity": "sha512-18gFfodGDIvDHl/Q26rzCeQuSrUAjPLJCoXXQcmBUbgx4rmzIgCqtpYHROWPmdH/xNwAd+hdkxFvwEpZFw7QMA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -5442,15 +5438,15 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
+      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.21.4",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -6888,9 +6884,12 @@
       }
     },
     "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
@@ -8729,9 +8728,9 @@
       }
     },
     "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -23364,10 +23363,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "hasInstallScript": true,
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -26679,15 +26677,6 @@
         "regexpu-core": "^5.1.0"
       }
     },
-    "@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "requires": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
-      }
-    },
     "@babel/helper-define-polyfill-provider": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
@@ -26742,11 +26731,11 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       }
     },
     "@babel/helper-module-transforms": {
@@ -26773,9 +26762,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w=="
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.18.9",
@@ -26824,10 +26813,15 @@
         "@babel/types": "^7.18.6"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w=="
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -27439,12 +27433,11 @@
       }
     },
     "@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.20.7.tgz",
+      "integrity": "sha512-Jq14o707UCRcGrdWa3qyA9TMoa/dMi9GfrphmwsppuZ3jxbDqRXHrQkjLN87sopIV3Zlp8SRZS48+S9ABcmC7g==",
       "requires": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -27728,11 +27721,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
-      "integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.21.5",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -27788,17 +27782,17 @@
       "dev": true
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -28823,9 +28817,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.12.2-tpml--img-stretch-issue.3",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.3.tgz",
-      "integrity": "sha512-15DH18u9A2XCS5mWZTGmgiNsIfA+7YB87HIhfPvyaQRmMAFYygKLr0iVichfJI/if5ypkO4pf3whetUZsPglvQ==",
+      "version": "2.12.2-tpml--img-stretch-issue.4",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.2-tpml--img-stretch-issue.4.tgz",
+      "integrity": "sha512-18gFfodGDIvDHl/Q26rzCeQuSrUAjPLJCoXXQcmBUbgx4rmzIgCqtpYHROWPmdH/xNwAd+hdkxFvwEpZFw7QMA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -30692,15 +30686,15 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
+      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.21.4",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
       }
     },
     "babel-plugin-syntax-class-properties": {
@@ -31980,9 +31974,9 @@
       }
     },
     "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -33410,9 +33404,9 @@
       }
     },
     "css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -44910,9 +44904,9 @@
       "requires": {}
     },
     "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.17.1",
+    "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.12.2",
+    "@quintype/amp": "^2.12.3-tpml--img-stretch-issue.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.2",
+    "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.3",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7-tpml-image-stretch-issue.0",
+  "version": "7.19.7-tpml-image-stretch-issue.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.8",
+  "version": "7.19.9-tpml-image-stretch-issue.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.6",
+  "version": "7.19.7-tpml-image-stretch-issue.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.12.1",
+    "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.2",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
+    "@quintype/amp": "^2.17.2",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.15.0-tpml--img-stretch-issue.0",
+    "@quintype/amp": "^2.17.2-tpml-image-stretch-issue.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.3",
+    "@quintype/amp": "^2.12.2-tpml--img-stretch-issue.4",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.14.0",
+    "@quintype/amp": "^2.15.0-tpml--img-stretch-issue.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7",
+  "version": "7.19.8-tpml-image-stretch-issue.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.7-tpml-image-stretch-issue.1",
+  "version": "7.19.7-tpml-image-stretch-issue.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.12",
+  "version": "7.19.13-tpml-image-stretch-issue.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
# Description

TPML was facing an issue for migrated stories where image metadata is not matching with actual image dimension, thats when hero image is stretched on AMP.


Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/839

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/437
