### PR TITLE
Focus point not set on HeroImage in Amp stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.13.0-amp-focus-point.1",
+        "@quintype/amp": "^2.14.1-amp-focus-point.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.13.0-amp-focus-point.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.1.tgz",
-      "integrity": "sha512-vIvZt6hjrHLfy41KkPe/pf58/VjimnkGCBnottfVKuhxHOV7pZV4ZjqhR1PzaQvBN3UtqZQDUs2RtdG3Mdp9Mg==",
+      "version": "2.14.1-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
+      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.13.0-amp-focus-point.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.1.tgz",
-      "integrity": "sha512-vIvZt6hjrHLfy41KkPe/pf58/VjimnkGCBnottfVKuhxHOV7pZV4ZjqhR1PzaQvBN3UtqZQDUs2RtdG3Mdp9Mg==",
+      "version": "2.14.1-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
+      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.13.0-amp-focus-point.0",
+        "@quintype/amp": "^2.13.0-amp-focus-point.1",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.13.0-amp-focus-point.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.0.tgz",
-      "integrity": "sha512-sIFnz7Gj6/Is6OH2OKz1PyUkNLfVpngSVR0gmMWITLhUl2Uzif+R9nZzKjuk/zsurGpDaSlLRICb47y0qLAf3Q==",
+      "version": "2.13.0-amp-focus-point.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.1.tgz",
+      "integrity": "sha512-vIvZt6hjrHLfy41KkPe/pf58/VjimnkGCBnottfVKuhxHOV7pZV4ZjqhR1PzaQvBN3UtqZQDUs2RtdG3Mdp9Mg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.13.0-amp-focus-point.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.0.tgz",
-      "integrity": "sha512-sIFnz7Gj6/Is6OH2OKz1PyUkNLfVpngSVR0gmMWITLhUl2Uzif+R9nZzKjuk/zsurGpDaSlLRICb47y0qLAf3Q==",
+      "version": "2.13.0-amp-focus-point.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.1.tgz",
+      "integrity": "sha512-vIvZt6hjrHLfy41KkPe/pf58/VjimnkGCBnottfVKuhxHOV7pZV4ZjqhR1PzaQvBN3UtqZQDUs2RtdG3Mdp9Mg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.9-amp-focus-point.1",
+  "version": "7.19.9-amp-focus-point.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.9-amp-focus-point.1",
+      "version": "7.19.9-amp-focus-point.2",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.14.0",
+        "@quintype/amp": "^2.13.0-amp-focus-point.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.0.tgz",
-      "integrity": "sha512-+O7Wu3HBiXUDA00GEHL+wE27H4UpWh+lEpSNwhZnXw4CYaomJD17CaP+PZ7GOmzCc1fAdIvITIne6woCy2urhQ==",
+      "version": "2.13.0-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.0.tgz",
+      "integrity": "sha512-sIFnz7Gj6/Is6OH2OKz1PyUkNLfVpngSVR0gmMWITLhUl2Uzif+R9nZzKjuk/zsurGpDaSlLRICb47y0qLAf3Q==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.0.tgz",
-      "integrity": "sha512-+O7Wu3HBiXUDA00GEHL+wE27H4UpWh+lEpSNwhZnXw4CYaomJD17CaP+PZ7GOmzCc1fAdIvITIne6woCy2urhQ==",
+      "version": "2.13.0-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.13.0-amp-focus-point.0.tgz",
+      "integrity": "sha512-sIFnz7Gj6/Is6OH2OKz1PyUkNLfVpngSVR0gmMWITLhUl2Uzif+R9nZzKjuk/zsurGpDaSlLRICb47y0qLAf3Q==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.8",
+  "version": "7.19.9-amp-focus-point.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.8",
+      "version": "7.19.9-amp-focus-point.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.9-amp-focus-point.0",
+  "version": "7.19.9-amp-focus-point.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.9-amp-focus-point.0",
+      "version": "7.19.9-amp-focus-point.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.8",
+  "version": "7.19.9-amp-focus-point.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.13.0-amp-focus-point.1",
+    "@quintype/amp": "^2.14.1-amp-focus-point.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.14.0",
+    "@quintype/amp": "^2.13.0-amp-focus-point.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.9-amp-focus-point.1",
+  "version": "7.19.9-amp-focus-point.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.9-amp-focus-point.0",
+  "version": "7.19.9-amp-focus-point.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.13.0-amp-focus-point.0",
+    "@quintype/amp": "^2.13.0-amp-focus-point.1",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",


### PR DESCRIPTION
Currently , if AspectRatio is not passed, under AMP stories, the image height is taken from metadata , not cropping as per focus point;

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/857

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/442
