### PR TITLE
Add support for custom max-age value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22",
+  "version": "7.19.23-custom-maxage.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.22",
+      "version": "7.19.23-custom-maxage.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22-staticPageHeader.0",
+  "version": "7.19.22-custom-maxage.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.22-staticPageHeader.0",
+      "version": "7.19.22-custom-maxage.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22-staticPageHeader.0",
+  "version": "7.19.22-custom-maxage.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22",
+  "version": "7.19.23-custom-maxage.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/handlers/cdn-caching.js
+++ b/server/handlers/cdn-caching.js
@@ -6,6 +6,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
   cacheKeys,
   cdnProvider = "cloudflare",
   config,
+  maxAge = "15",
   sMaxAge = "900",
   networkOnly = false,
 }) {
@@ -42,7 +43,7 @@ exports.addCacheHeadersToResult = function addCacheHeadersToResult({
       } else {
         res.setHeader(
           "Cache-Control",
-          `public,max-age=15,s-maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`
+          `public,max-age=${maxAge},s-maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`
         );
         cdnProviderVal === "akamai" &&
           res.setHeader("Edge-Control", `public,maxage=${sMaxAge},stale-while-revalidate=1000,stale-if-error=14400`);

--- a/server/handlers/custom-route-handler.js
+++ b/server/handlers/custom-route-handler.js
@@ -54,7 +54,7 @@ exports.customRouteHandler = function customRouteHandler(
   req,
   res,
   next,
-  { config, client, loadData, loadErrorData, renderLayout, logError, seo, domainSlug, cdnProvider = null, sMaxAge }
+  { config, client, loadData, loadErrorData, renderLayout, logError, seo, domainSlug, cdnProvider = null, sMaxAge, maxAge }
 ) {
   const url = urlLib.parse(req.url, true);
   const path = req.params[0].endsWith("/") ? req.params[0].slice(0, -1) : req.params[0];
@@ -74,6 +74,7 @@ exports.customRouteHandler = function customRouteHandler(
           cdnProvider: cdnProvider,
           config: config,
           sMaxAge,
+          maxAge,
         });
 
         let destination = page["destination-path"] || "/";
@@ -93,6 +94,7 @@ exports.customRouteHandler = function customRouteHandler(
           cdnProvider: cdnProvider,
           config: config,
           sMaxAge,
+          maxAge,
         });
         addStaticPageMimeType({ res, page });
 

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -230,6 +230,7 @@ exports.handleIsomorphicDataLoad = function handleIsomorphicDataLoad(
     redirectToLowercaseSlugs,
     sMaxAge,
     networkOnly,
+    maxAge,
   }
 ) {
   const url = urlLib.parse(req.query.path || "/", true);
@@ -302,6 +303,7 @@ exports.handleIsomorphicDataLoad = function handleIsomorphicDataLoad(
         config: config,
         sMaxAge,
         networkOnly,
+        maxAge,
       });
       const seoInstance = getSeoInstance(seo, config, result.pageType);
       res.json(
@@ -423,6 +425,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
     shouldEncodeAmpUri,
     publisherConfig,
     sMaxAge,
+    maxAge,
   }
 ) {
   const url = urlLib.parse(req.url, true);
@@ -437,6 +440,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
         cdnProvider: cdnProvider,
         config: config,
         sMaxAge: result.pageType === "tag-page" ? 600 : sMaxAge,
+        maxAge: maxAge,
       });
       return res.redirect(301, result.data.location);
     }
@@ -463,6 +467,7 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
       cdnProvider: cdnProvider,
       config: config,
       sMaxAge: result.pageType === "tag-page" ? 600 : sMaxAge,
+      maxAge: maxAge,
     });
 
     if (preloadJs) {
@@ -537,6 +542,7 @@ exports.handleStaticRoute = function handleStaticRoute(
     oneSignalServiceWorkers,
     publisherConfig,
     sMaxAge,
+    maxAge,
   }
 ) {
   const url = urlLib.parse(path);
@@ -577,6 +583,7 @@ exports.handleStaticRoute = function handleStaticRoute(
         cdnProvider: cdnProvider,
         config: config,
         sMaxAge,
+        maxAge,
       });
 
       const oneSignalScript = oneSignalServiceWorkers ? getOneSignalScript({ config, publisherConfig }) : null;

--- a/server/handlers/story-redirect.js
+++ b/server/handlers/story-redirect.js
@@ -6,7 +6,7 @@ exports.redirectStory = function redirectStory(
   req,
   res,
   next,
-  { logError, config, client, cdnProvider = null, sMaxAge }
+  { logError, config, client, cdnProvider = null, sMaxAge, maxAge }
 ) {
   const storySlug = req.params.storySlug.toLowerCase() || "";
   return Story.getStoryBySlug(client, storySlug)
@@ -18,6 +18,7 @@ exports.redirectStory = function redirectStory(
           cdnProvider: cdnProvider,
           config: config,
           sMaxAge,
+          maxAge,
         });
         return res.redirect(301, `/${story.slug}`);
       } else {


### PR DESCRIPTION
# Description

`opts.maxAge` Support overriding of proxied response cache header `maxage` from Sketches. For Breaking News and if the cacheability is Private, it is not overwritten instead the cache control will be the same as how it's set in sketches. We can set `upstreamRoutesMaxage: 15` under `publisher` in publisher.yml config file that comes from BlackKnight or pass maxAge as a param.

`maxAge` Overrides the max-age value, the default value is set to 15 seconds. We can set `isomorphicRoutesMaxage: 15` under `publisher` in publisher.yml config file that comes from BlackKnight or pass maxAge as a param.

Fixes # (issue-reference)
Add customization for max age

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
