### PR TITLE
Amp text overlap issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "files.trimTrailingWhitespace": true,
   "editor.codeActionsOnSave": {
     "source.organizeImports": true
-  }
+  },
+  "editor.acceptSuggestionOnEnter": "on"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.17.8",
+        "@quintype/amp": "^2.17.9-text-overlapping-issue.0",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.8.tgz",
-      "integrity": "sha512-xuks1AJaD5iyYcaYvZviJk6h2aP2rkQM6ubIkc8hACzETZFhDItDJpoXnKdwTBkgIe2feH+tOwPM7tHbLZOXqw==",
+      "version": "2.17.9-text-overlapping-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.9-text-overlapping-issue.0.tgz",
+      "integrity": "sha512-eS4D5RcBE1kPNFgvoXSsG6xG+qYvGPWSenKEywTstTvP6U1GnJ6RLWWKGgMkijGGl6gXUC+NnTOEsQqFeTjHgg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -28823,9 +28823,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.8.tgz",
-      "integrity": "sha512-xuks1AJaD5iyYcaYvZviJk6h2aP2rkQM6ubIkc8hACzETZFhDItDJpoXnKdwTBkgIe2feH+tOwPM7tHbLZOXqw==",
+      "version": "2.17.9-text-overlapping-issue.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.9-text-overlapping-issue.0.tgz",
+      "integrity": "sha512-eS4D5RcBE1kPNFgvoXSsG6xG+qYvGPWSenKEywTstTvP6U1GnJ6RLWWKGgMkijGGl6gXUC+NnTOEsQqFeTjHgg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22",
+  "version": "7.19.23-amp-text-overlap-issue.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.19.22",
+      "version": "7.19.23-amp-text-overlap-issue.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/quintype/quintype-node-framework#readme",
   "dependencies": {
     "@ampproject/toolbox-optimizer": "2.8.3",
-    "@quintype/amp": "^2.17.8",
+    "@quintype/amp": "^2.17.9-text-overlapping-issue.0",
     "@quintype/backend": "^2.3.3",
     "@quintype/components": "^3.3.0",
     "@quintype/prerender-node": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.19.22",
+  "version": "7.19.23-amp-text-overlap-issue.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
# Description
includes the changes for Text overlapping issue in visual stories  -

line height rule from 1 to "normal" ,
overlay background
font color
in amp library for Visual Stories .

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/932

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/458

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
