### PR TITLE
Redirect for visual stories

### DIFF
--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -511,6 +511,13 @@ exports.handleIsomorphicRoute = function handleIsomorphicRoute(
       if (!result) {
         return next();
       }
+      const pageType = result.pageType;
+      const subPageType = result.subPageType;
+      if (pageType === "story-page" && subPageType === "visual-story") {
+        const storySlug = _.get(result, ["data", "story", "slug"]);
+        if (storySlug && (storySlug.startsWith("ampstories") || storySlug.startsWith("/ampstories")))
+          return res.redirect(301, storySlug);
+      }
       return new Promise((resolve) => resolve(writeResponse(result)))
         .catch((e) => {
           logError(e);


### PR DESCRIPTION
https://github.com/quintype/page-builder/issues/2652

## The problem: ##
- If you put `site:www.filmcompanion.in inurl:web-stories -ampstories` in google search you'll find stories that are actually visual stories but are opening as normal text stories in the FE
- Take an example of one of the results listed under the above query - `https://www.filmcompanion.in/web-stories/ileana-dcruz-on-being-realistic-and-finding-the-right-balance-in-her-acting-roles`. This URL is wrong since it doesn't follow our convention that all visual stories must be of form `/ampstories/~slug~`. But for reasons not fully known to us, google is crawling these urls. The correct URL here would be `https://www.filmcompanion.in/ampstories/web-stories/ileana-dcruz-on-being-realistic-and-finding-the-right-balance-in-her-acting-roles` - this opens correctly as a visual story
- this is resulting in there being two versions of the same story which is not good

## The fix: ##
- We have a route matcher for `/ampstories` which will handle visual stories
- so in isomorphicHandler if it's a visual-story, I'm 301 redirecting to the story slug (which will have the correct URL of form `/ampstories/~slug~`)
