### PR TITLE
fix: visual stories throwing 404

### DIFF
--- a/server/amp/handlers/story-page.js
+++ b/server/amp/handlers/story-page.js
@@ -41,7 +41,7 @@ async function ampStoryPageHandler(
 ) {
   try {
     const opts = cloneDeep(rest);
-    const isCorrectAmpPath = req.path.startsWith(`${getAmpPageBasePath(opts, config)}/`);
+    const isCorrectAmpPath = req.path.startsWith(`${getAmpPageBasePath(opts, config)}/`) || isVisualStory;
     if (!isCorrectAmpPath) {
       return next();
     }


### PR DESCRIPTION
**Issue:**
visual stories are throwing 404

**Reason:**
while adding support to disable amp for specific stories, visual stories are not handled. This is causing all the visual stories to throw 404. 

**Fix:**
Add a condition to check a visual story and consider it as a correct amp path 