### PR TITLE
[fix]: enable wildcard api route for sketches proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.30.3-sub-dir-routes.0",
+  "version": "7.30.3-sub-dir-routes.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.30.3-sub-dir-routes.0",
+      "version": "7.30.3-sub-dir-routes.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.30.2",
+  "version": "7.30.3-sub-dir-routes.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.30.2",
+      "version": "7.30.3-sub-dir-routes.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.30.3-sub-dir-routes.0",
+  "version": "7.30.3-sub-dir-routes.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.30.2",
+  "version": "7.30.3-sub-dir-routes.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -114,7 +114,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     "/api/instant-articles.rss",
   ];
 
-  app.all("/api/*", sketchesProxy);
+  app.all("*/api/*", sketchesProxy);
   app.all("/login", sketchesProxy);
   app.all("/qlitics.js", sketchesProxy);
   app.all("/auth.form", sketchesProxy);

--- a/server/routes.js
+++ b/server/routes.js
@@ -114,6 +114,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     "/api/instant-articles.rss",
   ];
 
+  app.all("/api/*", sketchesProxy);
   app.all("*/api/*", sketchesProxy);
   app.all("/login", sketchesProxy);
   app.all("/qlitics.js", sketchesProxy);

--- a/test/integration/sketches-proxy-test.js
+++ b/test/integration/sketches-proxy-test.js
@@ -49,6 +49,19 @@ describe("Sketches Proxy", function () {
         .then(done);
     });
 
+    it("forwards subdirectory api requests to sketches", function (done) {
+      supertest(buildApp())
+        .get("/anything/api/v1/config")
+        .expect(200)
+        .then((res) => {
+          const { method, url, host } = JSON.parse(res.text);
+          assert.equal("GET", method);
+          assert.equal("/anything/api/v1/config", url);
+          assert.equal("127.0.0.1", host);
+        })
+        .then(done);
+    });
+
     it("forwards custom routes to sketches", function (done) {
       supertest(buildApp())
         .get("/custom-route")


### PR DESCRIPTION

Fixes : https://github.com/quintype/page-builder/issues/3419

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
