### PR TITLE
feat(app) : adds qt-trace-id for sketches requests 🍭 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.2",
+  "version": "7.33.1-qttrace.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.2",
+      "version": "7.33.1-qttrace.3",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "redux": "^4.1.1",
         "request-promise": "^4.2.6",
         "sleep-promise": "^9.1.0",
+        "uuid": "^11.0.5",
         "winston": "3.3.3"
       },
       "devDependencies": {
@@ -14394,6 +14395,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -23157,6 +23167,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -25276,12 +25295,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -38571,6 +38593,12 @@
           "requires": {
             "aggregate-error": "^3.0.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -45534,6 +45562,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-list-map": {
@@ -47200,10 +47236,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="
     },
     "v8-compile-cache": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.0",
+  "version": "7.33.1-qttrace.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.0",
+      "version": "7.33.1-qttrace.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.1",
+  "version": "7.33.1-qttrace.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.1",
+      "version": "7.33.1-qttrace.2",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.0",
+  "version": "7.33.1-qttrace.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.0",
+      "version": "7.33.1-qttrace.1",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.3",
+  "version": "7.33.1-qttrace.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.3",
+      "version": "7.33.1-qttrace.4",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.5",
+  "version": "7.33.1-qttrace.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.5",
+      "version": "7.33.1-qttrace.6",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.4",
+  "version": "7.33.1-qttrace.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.4",
+      "version": "7.33.1-qttrace.5",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.6",
+  "version": "7.33.1-qttrace.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1-qttrace.6",
+      "version": "7.33.1-qttrace.7",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.2",
+  "version": "7.33.1-qttrace.3",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.1",
+  "version": "7.33.1-qttrace.2",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.0",
+  "version": "7.33.1-qttrace.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.0",
+  "version": "7.33.1-qttrace.1",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "redux": "^4.1.1",
     "request-promise": "^4.2.6",
     "sleep-promise": "^9.1.0",
+    "uuid": "^11.0.5",
     "winston": "3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.4",
+  "version": "7.33.1-qttrace.5",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.3",
+  "version": "7.33.1-qttrace.4",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.5",
+  "version": "7.33.1-qttrace.6",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1-qttrace.6",
+  "version": "7.33.1-qttrace.7",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -104,14 +104,16 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     // Attach QT-TRACE-ID to all the request going to sketches.
     const logger = require("./logger");
     const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
-    const { path, headers } = req;
+    const { path } = req;
     const { statusCode, method, statusMessage } = res;
+    req.headers['qt-trace-id'] = qtTraceId;
+
     const loggedDataAttributes = {
       request: {
         host: getClient(req.hostname).getHostname(),
         path,
         time: Date.now(),
-        headers
+        headers: req.headers
       },
       response: {
         statusCode,
@@ -125,9 +127,6 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
       logged_data: loggedDataAttributes,
       message: `PATH => ${path}`
     });
-
-    console.log("SKETCHES OUTBOUND REQUEST", getClient(req.hostname).getHostname(), req.originalUrl, qtTraceId)
-    req.headers['qt-trace-id'] = qtTraceId;
 
     return apiProxy.web(req, res);
   };

--- a/server/routes.js
+++ b/server/routes.js
@@ -104,7 +104,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     // Attach QT-TRACE-ID to all the request going to sketches.
     const logger = require("./logger");
     const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
-    const { path, } = req;
+    const { path } = req;
     const { statusCode, method, statusMessage, headers } = res;
     req.headers['qt-trace-id'] = qtTraceId;
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -104,8 +104,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     // Attach QT-TRACE-ID to all the request going to sketches.
     const logger = require("./logger");
     const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
-    const { path } = req;
-    const { statusCode, method, statusMessage } = res;
+    const { path, } = req;
+    const { statusCode, method, statusMessage, headers } = res;
     req.headers['qt-trace-id'] = qtTraceId;
 
     const loggedDataAttributes = {

--- a/server/routes.js
+++ b/server/routes.js
@@ -76,6 +76,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
 
   parseInt(_sMaxAge) > 0 &&
     apiProxy.on('proxyRes', function (proxyRes, req) {
+      proxyRes.headers['qt-trace-id'] = get(proxyRes, ['headers', 'qt-trace-id'], '')
       const pathName = get(req, ['originalUrl'], '').split('?')[0]
       const checkForExcludeRoutes = excludeRoutes.some(path => {
         const matchFn = match(path, { decode: decodeURIComponent })
@@ -88,6 +89,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     })
   parseInt(_maxAge) > 0 &&
     apiProxy.on('proxyRes', function (proxyRes, req) {
+      proxyRes.headers['qt-trace-id'] = get(proxyRes, ['headers', 'qt-trace-id'], '')
       const pathName = get(req, ['originalUrl'], '').split('?')[0]
       const checkForExcludeRoutes = excludeRoutes.some(path => {
         const matchFn = match(path, { decode: decodeURIComponent })

--- a/server/routes.js
+++ b/server/routes.js
@@ -97,8 +97,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     })
 
   const sketchesProxy = (req, res) => {
-    const { req, res } = logRequest(req, res);
-    return apiProxy.web(req, res);
+    const { req: modifiedRequest, res: modifiedResponse } = logRequest(req, res);
+    return apiProxy.web(modifiedRequest, modifiedResponse);
   };
 
   app.get('/ping', (req, res) => {

--- a/server/routes.js
+++ b/server/routes.js
@@ -97,7 +97,7 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
     })
 
   const sketchesProxy = (req, res) => {
-    logRequest(req, res);
+    const { req, res } = logRequest(req, res);
     return apiProxy.web(req, res);
   };
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -30,7 +30,6 @@ const get = require('lodash/get')
 const { URL } = require('url')
 const prerender = require('@quintype/prerender-node')
 const { v4: uuidv4 } = require('uuid');
-const logger = require('./logger')
 const { logRequest } = require('./utils/request')
 
 /**

--- a/server/routes.js
+++ b/server/routes.js
@@ -66,6 +66,8 @@ exports.upstreamQuintypeRoutes = function upstreamQuintypeRoutes(
   })
 
   apiProxy.on('proxyReq', (proxyReq, req, res, options) => {
+    const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
+    proxyReq.setHeader('qt-trace-id', qtTraceId)
     proxyReq.setHeader('Host', getClient(req.hostname).getHostname())
   })
 

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -1,0 +1,33 @@
+const { v4: uuidv4 } = require('uuid');
+
+export const logRequest = (req, res) => {
+  if (!req || !res) return;
+
+  const logger = require("../logger");
+  const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
+  const { path } = req;
+  const { statusCode, method, statusMessage, headers } = res;
+
+  req.headers['qt-trace-id'] = qtTraceId;
+
+  const loggedDataAttributes = {
+    request: {
+      host: getClient(req.hostname).getHostname(),
+      path,
+      time: Date.now(),
+      headers: req.headers
+    },
+    response: {
+      statusCode,
+      method,
+      headers,
+      statusMessage
+    }
+  };
+
+  return logger.info({
+    level: 'info',
+    logged_data: loggedDataAttributes,
+    message: `PATH => ${path}`
+  });
+}

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -1,8 +1,8 @@
+import { getClient } from '../api-client';
 const { v4: uuidv4 } = require('uuid');
 
-export const logRequest = (req, res) => {
-  if (!req || !res) return;
 
+export const logRequest = (req, res) => {
   const logger = require("../logger");
   const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
   const { path } = req;

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -1,20 +1,10 @@
-import { v4 as uuidv4 } from 'uuid';
-
 export const logRequest = (req, res) => {
   const logger = require("../logger");
-  const getClient = require('../api-client').getClient;
-
-
-
-  const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
   const { path } = req;
   const { statusCode, method, statusMessage, headers } = res;
-
-  req.headers['qt-trace-id'] = qtTraceId;
-
   const loggedDataAttributes = {
     request: {
-      host: getClient(req.hostname).getHostname(),
+      host: req.headers['host'],
       path,
       time: Date.now(),
       headers: req.headers
@@ -26,12 +16,9 @@ export const logRequest = (req, res) => {
       statusMessage
     }
   };
-
-  logger.info({
+  return logger.info({
     level: 'info',
     logged_data: loggedDataAttributes,
     message: `PATH => ${path}`
   });
-
-  return { req, res }
 }

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -2,7 +2,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const logRequest = (req, res) => {
   const logger = require("../logger");
-  const getClient = require('./api-client').getClient;
+  const getClient = require('../api-client').getClient;
+
+
 
   const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
   const { path } = req;

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -1,4 +1,4 @@
-export const logRequest = (req, res) => {
+const logRequest = (req, res) => {
   const logger = require("../logger");
   const { path } = req;
   const { statusCode, method, statusMessage, headers } = res;
@@ -22,3 +22,7 @@ export const logRequest = (req, res) => {
     message: `PATH => ${path}`
   });
 }
+
+module.exports = {
+  logRequest
+};

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -1,9 +1,9 @@
-import { getClient } from '../api-client';
-const { v4: uuidv4 } = require('uuid');
-
+import { v4 as uuidv4 } from 'uuid';
 
 export const logRequest = (req, res) => {
   const logger = require("../logger");
+  const getClient = require('./api-client').getClient;
+
   const qtTraceId = (req && req.headers && req.headers['qt-trace-id']) || uuidv4();
   const { path } = req;
   const { statusCode, method, statusMessage, headers } = res;

--- a/server/utils/request.js
+++ b/server/utils/request.js
@@ -25,9 +25,11 @@ export const logRequest = (req, res) => {
     }
   };
 
-  return logger.info({
+  logger.info({
     level: 'info',
     logged_data: loggedDataAttributes,
     message: `PATH => ${path}`
   });
+
+  return { req, res }
 }


### PR DESCRIPTION
# Description

- Adds `qt-trace-id ` for all the sketches requests.
- Enable Kibana Logs for outbound requests to sketches.

Fixes # (issue-reference)
https://github.com/quintype/ahead/issues/1067

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
