### PR TITLE
feat(Story Route): Support URL path in params when storySlug param has no dynamic value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1",
+  "version": "7.33.2-fix-story-route.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/framework",
-      "version": "7.33.1",
+      "version": "7.33.2-fix-story-route.0",
       "license": "ISC",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/framework",
-  "version": "7.33.1",
+  "version": "7.33.2-fix-story-route.0",
   "description": "Libraries to help build Quintype Node.js apps",
   "main": "index.js",
   "engines": {

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -51,7 +51,7 @@ function loadDataForIsomorphicRoute(
     const redirectToLowercaseSlugsValue =
       typeof redirectToLowercaseSlugs === "function" ? redirectToLowercaseSlugs(config) : redirectToLowercaseSlugs;
     for (const match of matchAllRoutes(url.pathname, routes)) {
-      const storyPath = (match.pageType === "story-page" && !params.storySlug) ? { storySlug: url.pathname } : {};
+      const storyPath = (match.pageType === "story-page" && !match.params.storySlug) ? { storySlug: url.pathname } : {};
       const params = Object.assign({}, url.query, otherParams, match.params, storyPath);
 
       /* On story pages, if the slug contains any capital letters (latin), we want to

--- a/server/handlers/isomorphic-handler.js
+++ b/server/handlers/isomorphic-handler.js
@@ -51,7 +51,9 @@ function loadDataForIsomorphicRoute(
     const redirectToLowercaseSlugsValue =
       typeof redirectToLowercaseSlugs === "function" ? redirectToLowercaseSlugs(config) : redirectToLowercaseSlugs;
     for (const match of matchAllRoutes(url.pathname, routes)) {
-      const params = Object.assign({}, url.query, otherParams, match.params);
+      const storyPath = (match.pageType === "story-page" && !params.storySlug) ? { storySlug: url.pathname } : {};
+      const params = Object.assign({}, url.query, otherParams, match.params, storyPath);
+
       /* On story pages, if the slug contains any capital letters (latin), we want to
        * redirect the browser to the URL having all lowercase letters. We need to be
        * wary of any asset routes that might make its way here and get wrongly redirected.


### PR DESCRIPTION
fix: https://github.com/quintype/page-builder/issues/3673

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
