### PR TITLE
fix(jsembed): fallback support for non-iframe elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ampproject/toolbox-optimizer": "2.8.3",
         "@grpc/grpc-js": "^1.12.5",
         "@jsdoc/salty": "^0.2.9",
-        "@quintype/amp": "^2.21.4-test-jsembed.1",
+        "@quintype/amp": "^2.21.4",
         "@quintype/backend": "^2.7.0",
         "@quintype/components": "^3.5.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -3809,9 +3809,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@quintype/amp": {
-      "version": "2.21.4-test-jsembed.1",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.21.4-test-jsembed.1.tgz",
-      "integrity": "sha512-vo4t5kXYKNNR/sjCiWsOnl3hvLIABOudqkmEvCkXl1twagcAl/ebgreIEslPSfRWSoXJiFdykDSb1YCpnoxm4g==",
+      "version": "2.21.4",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.21.4.tgz",
+      "integrity": "sha512-LLUz5VVhfsCI9NOkfXldoTH4Zn03Q/Injpj1KDTG3R94NVuqKWnOHgu1dL6494Usjcav1rNdK8Xtro8reeRxig==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@ampproject/toolbox-optimizer": "2.8.3",
     "@grpc/grpc-js": "^1.12.5",
     "@jsdoc/salty": "^0.2.9",
-    "@quintype/amp": "^2.21.4-test-jsembed.1",
+    "@quintype/amp": "^2.21.4",
     "@quintype/backend": "^2.7.0",
     "@quintype/components": "^3.5.0",
     "@quintype/prerender-node": "^3.2.26",


### PR DESCRIPTION
fix: https://github.com/quintype/page-builder/issues/3923

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 7.34.3-test-jsembed.1.
  * Upgraded the "@quintype/amp" dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->